### PR TITLE
Fix & Refactor `start_iginx.sh` and Try fix job cancel

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -590,8 +590,8 @@ public class IginxWorker implements IService.Iface {
     @Override
     public Status cancelTransformJob(CancelTransformJobReq req) {
         TransformJobManager manager = TransformJobManager.getInstance();
-        manager.cancel(req.getJobId());
-        return RpcUtils.SUCCESS;
+        boolean success = manager.cancel(req.getJobId());
+        return success ? RpcUtils.SUCCESS : RpcUtils.FAILURE;
     }
 
     @Override

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/TransformIT.java
@@ -582,10 +582,12 @@ public class TransformIT {
             logger.info("job {} state is {}", jobId, jobState.toString());
 
             session.cancelTransformJob(jobId);
+            jobState = session.queryTransformJobStatus(jobId);
+            logger.info("After cancellation, job {} state is {}", jobId, jobState.toString());
+            assertEquals(JobState.JOB_CLOSED, jobState);
 
-            List<Long> finishedJobIds = session.showEligibleJob(JobState.JOB_CLOSED);
-
-            assertTrue(finishedJobIds.contains(jobId));
+            List<Long> closedJobIds = session.showEligibleJob(JobState.JOB_CLOSED);
+            assertTrue(closedJobIds.contains(jobId));
         } catch (SessionException | ExecutionException | InterruptedException e) {
             logger.error("Transform:  execute fail. Caused by:", e);
             fail();

--- a/test/src/test/resources/transform/transformer_sleep.py
+++ b/test/src/test/resources/transform/transformer_sleep.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import time
 
 
@@ -7,5 +6,5 @@ class SleepTransformer:
         pass
 
     def transform(self, rows):
-        time.sleep(5)
-        return rows
+        while True:
+            time.sleep(60)


### PR DESCRIPTION
# Fix & Refactor `start_iginx.sh`
* Make heap size computation compatible with Linux without `free` utility.
* Add heap opts into args of java to make it work.
* Unify script style and fix corner cases.
  For example:
  If `IGINX_HOME` contains `<space>` or `*`, `${IGINX_HOME}/path` can be corrupted by [Word Splitting](https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html) and [Filename expansion](https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html). Thus, `"${IGINX_HOME}"/path` should be used instead. With the double quote, the `{}` is absolutely redundant (It actually redundant without quote since `/` cannot be a part of variable name, but `""` make this even obvious to human without help from IDE).

# Try fix job cancel
* set sleep time to infinity
* add more log
* let cancel fail fast