### PR TITLE
Make lexer rule `ID` cannot match empty string

### DIFF
--- a/antlr/src/main/antlr4/cn/edu/tsinghua/iginx/sql/Sql.g4
+++ b/antlr/src/main/antlr4/cn/edu/tsinghua/iginx/sql/Sql.g4
@@ -834,7 +834,7 @@ DATETIME
     ;
 
 /** Allow unicode rule/token names */
-ID : NAME_CHAR*;
+ID : NAME_CHAR+;
 
 fragment
 NAME_CHAR


### PR DESCRIPTION
Fix "non-fragment lexer rule ID can match the empty string" warning.