### PR TITLE
Make test fail fast when cannot open session

### DIFF
--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/BaseSessionConcurrencyIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/BaseSessionConcurrencyIT.java
@@ -52,25 +52,17 @@ public abstract class BaseSessionConcurrencyIT {
     protected static final Logger logger = LoggerFactory.getLogger(BaseSessionIT.class);
 
     @Before
-    public void setUp() {
-        try {
-            session = new MultiConnection (new Session(defaultTestHost, defaultTestPort, defaultTestUser, defaultTestPass));
-            session.openSession();
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-        }
+    public void setUp() throws SessionException {
+        session = new MultiConnection(new Session(defaultTestHost, defaultTestPort, defaultTestUser, defaultTestPass));
+        session.openSession();
     }
 
     @After
-    public void tearDown() throws SessionException {
+    public void tearDown() throws SessionException, ExecutionException {
         if(!ifClearData) return;
 
-        try {
-            clearData();
-            session.closeSession();
-        } catch (ExecutionException e) {
-            logger.error(e.getMessage());
-        }
+        clearData();
+        session.closeSession();
     }
 
     protected void clearData() throws ExecutionException, SessionException {

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/BaseSessionPoolIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/BaseSessionPoolIT.java
@@ -1,27 +1,24 @@
 package cn.edu.tsinghua.iginx.integration;
 
-
 import cn.edu.tsinghua.iginx.pool.SessionPool;
 import org.junit.Before;
 
-public class BaseSessionPoolIT extends BaseSessionIT{
+public class BaseSessionPoolIT extends BaseSessionIT {
 
-    //check in BaseSessionIT for the initializations of MultiThreadTask before assignment
+    // check in BaseSessionIT for the initializations of MultiThreadTask before
+    // assignment
     private final int MaxMultiThreadTaskNum = 10;
+
     @Before
     @Override
     public void setUp() {
-        try {
-            session = new MultiConnection ( new SessionPool.Builder()
-                            .host(defaultTestHost)
-                            .port(defaultTestPort)
-                            .user(defaultTestUser)
-                            .password(defaultTestPass)
-                            .maxSize(MaxMultiThreadTaskNum)
-                            .build());
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-        }
+        session = new MultiConnection(new SessionPool.Builder()
+                .host(defaultTestHost)
+                .port(defaultTestPort)
+                .user(defaultTestUser)
+                .password(defaultTestPass)
+                .maxSize(MaxMultiThreadTaskNum)
+                .build());
     }
 
 }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/SQLSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/SQLSessionIT.java
@@ -51,12 +51,12 @@ public abstract class SQLSessionIT {
     protected String storageEngineType;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         if (isForSession) {
             session = new MultiConnection(
                 new Session(defaultTestHost, defaultTestPort, defaultTestUser, defaultTestPass));
         } else if (isForSessionPool) {
-            session = new MultiConnection (
+            session = new MultiConnection(
                     new SessionPool(new ArrayList<IginxInfo>() {{
                         add(new IginxInfo.Builder()
                                 .host("0.0.0.0")
@@ -73,20 +73,12 @@ public abstract class SQLSessionIT {
                                 .build());
                     }}));
         }
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/TagIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/TagIT.java
@@ -23,23 +23,15 @@ public class TagIT {
     private String CLEARDATAEXCP = "cn.edu.tsinghua.iginx.exceptions.ExecutionException: Caution: can not clear the data of read-only node.";
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         ifClearData = true;
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/TimePrecisionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/TimePrecisionIT.java
@@ -35,23 +35,18 @@ public class TimePrecisionIT {
     protected String storageEngineType;
 
     @BeforeClass
-    public static void setUp() {
-        if(isForSession)
-            session = new Session (defaultTestHost, defaultTestPort, defaultTestUser, defaultTestPass);
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
+    public static void setUp() throws SessionException {
+        if(isForSession) {
+            session = new Session(defaultTestHost, defaultTestPort, defaultTestUser, defaultTestPass);
+        } else if (isForSessionPool) {
+            // TODO
         }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/influxdb/InfluxDBHistoryDataCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/influxdb/InfluxDBHistoryDataCapacityExpansionIT.java
@@ -20,22 +20,14 @@ public class InfluxDBHistoryDataCapacityExpansionIT {
     }
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Test

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/iotdb/IoTDBHistoryDataCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/iotdb/IoTDBHistoryDataCapacityExpansionIT.java
@@ -31,7 +31,7 @@ public class IoTDBHistoryDataCapacityExpansionIT implements BaseCapacityExpansio
     }
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
         sessionPool =
                 new SessionPool.Builder()
@@ -41,21 +41,13 @@ public class IoTDBHistoryDataCapacityExpansionIT implements BaseCapacityExpansio
                         .password("root")
                         .maxSize(3)
                         .build();
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-            sessionPool.close();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
+        sessionPool.close();
     }
 
     @Test

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/parquet/ParquetHistoryDataCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/parquet/ParquetHistoryDataCapacityExpansionIT.java
@@ -16,22 +16,14 @@ public class ParquetHistoryDataCapacityExpansionIT {
     private static Session session;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Test

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/rest/RestAnnotationIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/rest/RestAnnotationIT.java
@@ -103,24 +103,14 @@ public class RestAnnotationIT {
 
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            LOGGER.error(e.getMessage());
-            fail();
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            LOGGER.error(e.getMessage());
-            fail();
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     //    @Before

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/rest/RestIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/rest/RestIT.java
@@ -23,22 +23,14 @@ public class RestIT {
     protected static Session session;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before
@@ -47,6 +39,7 @@ public class RestIT {
             execute("insert.json",TYPE.INSERT);
         } catch (Exception e) {
             logger.error("insertData fail. Caused by: {}.", e.toString());
+            fail();
         }
     }
 

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/TransformIT.java
@@ -93,22 +93,14 @@ public class TransformIT {
     }
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/UDFIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/udf/UDFIT.java
@@ -48,22 +48,14 @@ public class UDFIT {
     private static Session session;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws SessionException {
         session = new Session("127.0.0.1", 6888, "root", "root");
-        try {
-            session.openSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+        session.openSession();
     }
 
     @AfterClass
-    public static void tearDown() {
-        try {
-            session.closeSession();
-        } catch (SessionException e) {
-            logger.error(e.getMessage());
-        }
+    public static void tearDown() throws SessionException {
+        session.closeSession();
     }
 
     @Before


### PR DESCRIPTION
Before this change, some tests will be executed with `session.client == null`, producing lots of uninformative Null Pointer Exceptions. It takes extra efforts to find the useful error log.
After this change, errors occur during session opening, e.g. connection refused, will terminate the test and print stack trace instead of 1-line message at the top of tens of Null Pointer Exceptions' stack trace.