### PR TITLE
Enhance session pool

### DIFF
--- a/dataSources/filesystem/src/main/java/cn/edu/tsinghua/iginx/filesystem/exec/RemoteExecutor.java
+++ b/dataSources/filesystem/src/main/java/cn/edu/tsinghua/iginx/filesystem/exec/RemoteExecutor.java
@@ -65,10 +65,10 @@ public class RemoteExecutor implements Executor {
     if (filter != null && !filter.toString().isEmpty()) {
       req.setFilter(FilterTransformer.toFSFilter(filter));
     }
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       ProjectResp resp = client.executeProject(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (resp.getStatus().code == SUCCESS_CODE) {
         FSHeader fileDataHeader = resp.getHeader();
         List<DataType> dataTypes = new ArrayList<>();
@@ -151,10 +151,10 @@ public class RemoteExecutor implements Executor {
             dataView.getRawDataType().toString());
 
     InsertReq req = new InsertReq(storageUnit, fileDataRawData);
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       Status status = client.executeInsert(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (status.code == SUCCESS_CODE) {
         return new TaskExecuteResult(null, null);
       } else {
@@ -186,10 +186,10 @@ public class RemoteExecutor implements Executor {
       req.setKeyRanges(fsKeyRanges);
     }
 
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       Status status = client.executeDelete(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (status.code == SUCCESS_CODE) {
         return new TaskExecuteResult(null, null);
       } else {
@@ -203,10 +203,10 @@ public class RemoteExecutor implements Executor {
 
   @Override
   public List<Column> getColumnsOfStorageUnit(String storageUnit) throws PhysicalException {
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       GetColumnsOfStorageUnitResp resp = client.getColumnsOfStorageUnit(storageUnit);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       List<Column> columns = new ArrayList<>();
       resp.getPathList()
           .forEach(
@@ -227,10 +227,10 @@ public class RemoteExecutor implements Executor {
   @Override
   public Pair<ColumnsInterval, KeyInterval> getBoundaryOfStorage(String dataPrefix)
       throws PhysicalException {
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       GetBoundaryOfStorageResp resp = client.getBoundaryOfStorage(dataPrefix);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       return new Pair<>(
           new ColumnsInterval(resp.getStartColumn(), resp.getEndColumn()),
           new KeyInterval(resp.getStartKey(), resp.getEndKey()));

--- a/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/MongoDBStorage.java
+++ b/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/MongoDBStorage.java
@@ -86,7 +86,8 @@ public class MongoDBStorage implements IStorage {
                 builder ->
                     builder
                         .maxWaitTime(MAX_WAIT_TIME, TimeUnit.SECONDS)
-                        .maxSize(SESSION_POOL_MAX_SIZE))
+                        .maxSize(SESSION_POOL_MAX_SIZE)
+                        .maxConnectionIdleTime(60, TimeUnit.SECONDS))
             .build();
 
     return MongoClients.create(settings);

--- a/dataSources/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/exec/RemoteExecutor.java
+++ b/dataSources/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/exec/RemoteExecutor.java
@@ -67,10 +67,10 @@ public class RemoteExecutor implements Executor {
       req.setFilter(filter);
     }
 
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       ProjectResp resp = client.executeProject(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (resp.getStatus().code == SUCCESS_CODE) {
         ParquetHeader parquetHeader = resp.getHeader();
         List<DataType> dataTypes = new ArrayList<>();
@@ -155,10 +155,10 @@ public class RemoteExecutor implements Executor {
             dataView.getRawDataType().toString());
 
     InsertReq req = new InsertReq(storageUnit, parquetRawData);
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       Status status = client.executeInsert(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (status.code == SUCCESS_CODE) {
         return new TaskExecuteResult(null, null);
       } else {
@@ -242,10 +242,10 @@ public class RemoteExecutor implements Executor {
       req.setKeyRanges(parquetKeyRanges);
     }
 
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       Status status = client.executeDelete(req);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       if (status.code == SUCCESS_CODE) {
         return new TaskExecuteResult(null, null);
       } else {
@@ -317,10 +317,10 @@ public class RemoteExecutor implements Executor {
 
   @Override
   public List<Column> getColumnsOfStorageUnit(String storageUnit) throws PhysicalException {
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       GetColumnsOfStorageUnitResp resp = client.getColumnsOfStorageUnit(storageUnit);
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       List<Column> columnList = new ArrayList<>();
       resp.getTsList()
           .forEach(
@@ -338,10 +338,10 @@ public class RemoteExecutor implements Executor {
 
   @Override
   public Pair<ColumnsInterval, KeyInterval> getBoundaryOfStorage() throws PhysicalException {
-    try (TTransport transport = thriftConnPool.borrowAndOpenTransport()) {
+    try (TTransport transport = thriftConnPool.borrowTransport()) {
       Client client = new Client(new TBinaryProtocol(transport));
       GetStorageBoundaryResp resp = client.getBoundaryOfStorage();
-      thriftConnPool.returnAndCloseTransport(transport);
+      thriftConnPool.returnTransport(transport);
       return new Pair<>(
           new ColumnsInterval(resp.getStartColumn(), resp.getEndColumn()),
           new KeyInterval(resp.getStartKey(), resp.getEndKey()));

--- a/dataSources/postgresql/src/main/java/cn/edu/tsinghua/iginx/postgresql/PostgreSQLStorage.java
+++ b/dataSources/postgresql/src/main/java/cn/edu/tsinghua/iginx/postgresql/PostgreSQLStorage.java
@@ -97,7 +97,7 @@ public class PostgreSQLStorage implements IStorage {
     try {
       connection = DriverManager.getConnection(connUrl);
       Statement statement = connection.createStatement();
-      String sql = "alter system set idle_in_transaction_session_timeout='5min'";
+      String sql = "alter system set idle_in_transaction_session_timeout='1min'";
       statement.executeUpdate(sql);
       statement.close();
     } catch (SQLException e) {

--- a/dataSources/postgresql/src/main/java/cn/edu/tsinghua/iginx/postgresql/PostgreSQLStorage.java
+++ b/dataSources/postgresql/src/main/java/cn/edu/tsinghua/iginx/postgresql/PostgreSQLStorage.java
@@ -96,6 +96,10 @@ public class PostgreSQLStorage implements IStorage {
             meta.getIp(), meta.getPort(), username, password);
     try {
       connection = DriverManager.getConnection(connUrl);
+      Statement statement = connection.createStatement();
+      String sql = "alter system set idle_in_transaction_session_timeout='5min'";
+      statement.executeUpdate(sql);
+      statement.close();
     } catch (SQLException e) {
       throw new StorageInitializationException("cannot connect to " + meta);
     }

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>cn.edu.tsinghua</groupId>
             <artifactId>iginx-thrift</artifactId>
             <version>${project.version}</version>

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
@@ -108,7 +108,13 @@ public class ThriftConnPool {
     @Override
     public void activateObject(PooledObject<TTransport> pooledObject) throws Exception {
       TTransport transport = pooledObject.getObject();
-      transport.open();
+      if (transport == null) {
+        TTransport newTransport = new TSocket(ip, port);
+        newTransport.open();
+        pooledObject = new DefaultPooledObject<>(newTransport);
+      } else if (!transport.isOpen()) {
+        transport.open();
+      }
     }
 
     @Override

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
@@ -1,19 +1,17 @@
 package cn.edu.tsinghua.iginx.utils;
 
-import java.util.concurrent.ConcurrentLinkedDeque;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
-import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ThriftConnPool {
   private static final Logger logger = LoggerFactory.getLogger(ThriftConnPool.class);
-
-  private final ConcurrentLinkedDeque<TTransport> availableTransportQueue =
-      new ConcurrentLinkedDeque<>();
-
-  private static int size;
 
   private final int max_size;
 
@@ -29,6 +27,10 @@ public class ThriftConnPool {
 
   private final int port;
 
+  private GenericObjectPool<TTransport> pool;
+
+  private final long idleTimeout = 60 * 1000L;
+
   public ThriftConnPool(String ip, int port) {
     this(ip, port, DEFAULT_MAX_SIZE);
   }
@@ -37,113 +39,83 @@ public class ThriftConnPool {
     this.ip = ip;
     this.port = port;
     this.max_size = max_size;
-    size = 0;
+
+    GenericObjectPoolConfig<TTransport> poolConfig = new GenericObjectPoolConfig<>();
+    poolConfig.setMaxTotal(max_size);
+    poolConfig.setMinEvictableIdleTimeMillis(idleTimeout); // 设置空闲连接的超时时间
+
+    TSocketFactory socketFactory = new TSocketFactory(ip, port);
+    pool = new GenericObjectPool<>(socketFactory, poolConfig);
   }
 
-  public TTransport borrowAndOpenTransport() {
+  public TTransport borrowTransport() {
     try {
-      TTransport transport = borrowTransport();
-      if (transport != null && !transport.isOpen()) {
-        transport.open();
-      }
-      return transport;
-    } catch (TTransportException e) {
-      logger.error("creating new connection failed:" + e);
+      return pool.borrowObject();
+    } catch (Exception e) {
+      logger.error("borrowing connection failed:" + e);
       return null;
     }
-  }
-
-  private TTransport borrowTransport() {
-    if (isClosed()) {
-      logger.error("client pool closed.");
-      return null;
-    }
-    TTransport transport = availableTransportQueue.poll();
-    if (transport != null) {
-      return transport;
-    }
-
-    boolean canCreate = false;
-    synchronized (this) {
-      if (size < this.max_size) {
-        canCreate = true;
-      }
-    }
-
-    if (canCreate) {
-      try {
-        if (isClosed()) {
-          logger.error("connection pool closed.");
-          return null;
-        }
-        transport = newTransport();
-      } catch (TTransportException e) {
-        logger.error("creating new connection failed:" + e);
-        return null;
-      }
-      synchronized (this) {
-        size++;
-      }
-    } else {
-      long startTime = System.currentTimeMillis();
-      while (transport == null) {
-        synchronized (this) {
-          if (isClosed()) {
-            logger.error("connection pool closed.");
-            return null;
-          }
-          try {
-            this.wait(WAIT_TIME);
-            if (System.currentTimeMillis() - startTime > MAX_WAIT_TIME) {
-              logger.error("time out for connection.");
-              return null;
-            }
-          } catch (InterruptedException e) {
-            logger.error("the connection pool is damaged", e);
-            Thread.currentThread().interrupt();
-          }
-          transport = availableTransportQueue.poll();
-        }
-      }
-    }
-
-    return transport;
   }
 
   private synchronized boolean isClosed() {
     return closed;
   }
 
-  public void returnAndCloseTransport(TTransport transport) {
-    if (transport.isOpen()) {
-      transport.close();
-    }
+  public void returnTransport(TTransport transport) {
     if (isClosed()) {
       logger.warn("returning connection to a closed connection pool.");
       return;
     }
-    availableTransportQueue.offer(transport);
-    synchronized (this) {
-      this.notify();
-    }
-  }
-
-  private TTransport newTransport() throws TTransportException {
-    TTransport transport = new TSocket(this.ip, this.port);
-    if (!transport.isOpen()) {
-      transport.open();
-    }
-    return transport;
+    pool.returnObject(transport);
   }
 
   public void close() {
     logger.info("closing connection pool...");
-    for (TTransport transport : availableTransportQueue) {
-      transport.close();
+    pool.close();
+    closed = true;
+  }
+
+  public static class TSocketFactory implements PooledObjectFactory<TTransport> {
+    private final String ip;
+    private final int port;
+
+    public TSocketFactory(String ip, int port) {
+      this.ip = ip;
+      this.port = port;
     }
-    synchronized (this) {
-      closed = true;
-      availableTransportQueue.clear();
+
+    @Override
+    public PooledObject<TTransport> makeObject() throws Exception {
+      TTransport transport = new TSocket(ip, port);
+      transport.open();
+      return new DefaultPooledObject<>(transport);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<TTransport> pooledObject) throws Exception {
+      TTransport transport = pooledObject.getObject();
+      if (transport != null && transport.isOpen()) {
+        transport.close();
+      }
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<TTransport> pooledObject) {
+      TTransport transport = pooledObject.getObject();
+      return transport != null && transport.isOpen();
+    }
+
+    @Override
+    public void activateObject(PooledObject<TTransport> pooledObject) throws Exception {
+      TTransport transport = pooledObject.getObject();
+      if (transport != null && !transport.isOpen()) {
+        transport.open();
+      }
+    }
+
+    @Override
+    public void passivateObject(PooledObject<TTransport> pooledObject) throws Exception {
+      // No-op
     }
   }
 }

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 public class ThriftConnPool {
   private static final Logger logger = LoggerFactory.getLogger(ThriftConnPool.class);
 
-  private final int max_size;
+  private final int maxSize;
 
   private static final int DEFAULT_MAX_SIZE = 100;
 
@@ -35,13 +35,13 @@ public class ThriftConnPool {
     this(ip, port, DEFAULT_MAX_SIZE);
   }
 
-  public ThriftConnPool(String ip, int port, int max_size) {
+  public ThriftConnPool(String ip, int port, int maxSize) {
     this.ip = ip;
     this.port = port;
-    this.max_size = max_size;
+    this.maxSize = maxSize;
 
     GenericObjectPoolConfig<TTransport> poolConfig = new GenericObjectPoolConfig<>();
-    poolConfig.setMaxTotal(max_size);
+    poolConfig.setMaxTotal(maxSize);
     poolConfig.setMinEvictableIdleTimeMillis(idleTimeout); // 设置空闲连接的超时时间
 
     TSocketFactory socketFactory = new TSocketFactory(ip, port);

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/utils/ThriftConnPool.java
@@ -29,7 +29,7 @@ public class ThriftConnPool {
 
   private GenericObjectPool<TTransport> pool;
 
-  private final long idleTimeout = 60 * 1000L;
+  private final long idleTimeout = 60 * 10000L;
 
   public ThriftConnPool(String ip, int port) {
     this(ip, port, DEFAULT_MAX_SIZE);
@@ -108,14 +108,13 @@ public class ThriftConnPool {
     @Override
     public void activateObject(PooledObject<TTransport> pooledObject) throws Exception {
       TTransport transport = pooledObject.getObject();
-      if (transport != null && !transport.isOpen()) {
-        transport.open();
-      }
+      transport.open();
     }
 
     @Override
     public void passivateObject(PooledObject<TTransport> pooledObject) throws Exception {
-      // No-op
+      TTransport transport = pooledObject.getObject();
+      transport.close();
     }
   }
 }


### PR DESCRIPTION
支持在底层数据库连接时设置idle_timeout，实现连接池自动扩缩容
其中influxdb是一个"及连及用"的连接方式，不需要idle_timeout
iotdb12没有idle_timeout配置
redis具有默认idle_timeout配置
parquet和filesystem共用apaceh common pool
PG通过 alter system set idle_in_transaction_session_timeout='5min' 设置idle_timeout
mogodb设置连接池的maxConnectionIdleTime属性