### PR TITLE
feat(mongodb): analyze schema of dummy data by sampling documents

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -20,7 +20,7 @@ storageEngineList=127.0.0.1#6667#iotdb12#username=root#password=root#sessionPool
 #storageEngineList=127.0.0.1#5432#timescaledb#username=postgres#password=postgres
 #storageEngineList=127.0.0.1#5432#postgresql#username=postgres#password=postgres#has_data=false
 #storageEngineList=127.0.0.1#6667#parquet#dir=/path/to/your/parquet#dummy_dir=/path/to/your/data#iginx_port=6888#has_data=false#is_read_only=false#thrift_timeout=30000#thrift_pool_max_size=100#thrift_pool_min_evictable_idle_time_millis=600000#write_buffer_size=104857600#write_batch_size=1048576#flusher_permits=16#cache.capacity=1073741824#cache.timeout=PT1H#cache.soft_values=false#parquet.row_group_size=134217728#parquet.page_size=8192
-#storageEngineList=127.0.0.1#27017#mongodb#has_data=false
+#storageEngineList=127.0.0.1#27017#mongodb#has_data=false#schema.sample.size=1000
 #storageEngineList=127.0.0.1#6667#filesystem#dir=/path/to/your/filesystem#dummy_dir=/path/to/your/data#iginx_port=6888#chunk_size_in_bytes=1048576#memory_pool_size=100#has_data=false#is_read_only=false#thrift_timeout=5000#thrift_pool_max_size=100#thrift_pool_min_evictable_idle_time_millis=600000
 #storageEngineList=127.0.0.1#6379#redis#has_data=false#is_read_only=false#timeout=5000
 

--- a/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/MongoDBStorage.java
+++ b/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/MongoDBStorage.java
@@ -300,7 +300,7 @@ public class MongoDBStorage implements IStorage {
               db.getCollection(collectionName, BsonDocument.class);
           Map<String, DataType> sampleSchema = new SchemaSample(schemaSampleSize).query(collection);
           for (Map.Entry<String, DataType> entry : sampleSchema.entrySet()) {
-            columns.add(new Column(entry.getKey(), entry.getValue(), null, false));
+            columns.add(new Column(entry.getKey(), entry.getValue(), null, true));
           }
           continue;
         }

--- a/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/dummy/SchemaSample.java
+++ b/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/dummy/SchemaSample.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 IGinX of Tsinghua University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.edu.tsinghua.iginx.mongodb.dummy;
+
+import cn.edu.tsinghua.iginx.thrift.DataType;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Aggregates;
+import java.util.*;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+
+public class SchemaSample {
+
+  private final int schemaSampleSize;
+  private final PathTree tree = new PathTree();
+
+  public SchemaSample(int schemaSampleSize) {
+    this.schemaSampleSize = schemaSampleSize;
+    this.tree.put(Collections.singletonList("*").iterator());
+  }
+
+  public Map<String, DataType> query(MongoCollection<BsonDocument> collection) {
+    AggregateIterable<BsonDocument> sampleResult =
+        collection.aggregate(Collections.singletonList(getSampleStage()));
+
+    int count = 0;
+    ResultTable.Builder builder = new ResultTable.Builder();
+
+    try (MongoCursor<BsonDocument> cursor = sampleResult.cursor()) {
+      while (cursor.hasNext()) {
+        BsonDocument doc = cursor.next();
+        builder.add(count++, doc, tree);
+      }
+    }
+
+    String[] prefixes =
+        new String[] {
+          collection.getNamespace().getDatabaseName(),
+          collection.getNamespace().getCollectionName(),
+        };
+
+    ResultTable sampleTable = builder.build(prefixes);
+
+    Map<String, ResultColumn> columns = sampleTable.getColumns();
+    Map<String, DataType> schema = new HashMap<>(columns.size());
+
+    for (Map.Entry<String, ResultColumn> entry : columns.entrySet()) {
+      String path = entry.getKey();
+      ResultColumn column = entry.getValue();
+      DataType dataType = column.getType();
+      schema.put(path, dataType);
+    }
+
+    return schema;
+  }
+
+  private Bson getSampleStage() {
+    return Aggregates.sample(this.schemaSampleSize);
+  }
+}


### PR DESCRIPTION
### 描述

这个PR实现了通过采样数据来分析文档模式的功能，来使`show columns`显示更准确的列和类型。不过，由于mongodb没有固定的模式，通过采样分析的得到的模式可能与实际查询结果有出入。

### 配置参数

增加了对接层配置参数`schema.sample.size`，设置采样的文档数量，默认值为1000。

- 当值大于0时，通过采样分析提供dummy数据下 `show columns` 的结果；
- 否则，使用原来的方式为dummy数据显示一个大概的路径（即包含*）和固定的类型BINARY，例如db.coll.*。


