### PR TITLE
fix(core): correcting the load-data-as-first-command bug

### DIFF
--- a/.github/scripts/test/cli/test_infile.sh
+++ b/.github/scripts/test/cli/test_infile.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-COMMAND='LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, a, b, c, d);'
+COMMAND='LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, d, b, c, a);'
 
 SCRIPT_COMMAND="bash client/target/iginx-client-0.6.0-SNAPSHOT/sbin/start_cli.sh -e '{}'"
 

--- a/.github/scripts/test/cli/test_infile_macos.sh
+++ b/.github/scripts/test/cli/test_infile_macos.sh
@@ -4,4 +4,4 @@ set -e
 
 sh -c "chmod +x client/target/iginx-client-0.6.0-SNAPSHOT/sbin/start_cli.sh"
 
-sh -c "echo 'LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, a, b, c, d);' | xargs -0 -t -I F sh client/target/iginx-client-0.6.0-SNAPSHOT/sbin/start_cli.sh -e 'F'"
+sh -c "echo 'LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, d, b, c, a);' | xargs -0 -t -I F sh client/target/iginx-client-0.6.0-SNAPSHOT/sbin/start_cli.sh -e 'F'"

--- a/.github/scripts/test/cli/test_infile_windows.sh
+++ b/.github/scripts/test/cli/test_infile_windows.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-COMMAND='LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, a, b, c, d);'
+COMMAND='LOAD DATA FROM INFILE "'"test/src/test/resources/fileReadAndWrite/csv/test.csv"'" AS CSV INTO t(key, d, b, c, a);'
 
 bash -c "client/target/iginx-client-0.6.0-SNAPSHOT/sbin/start_cli.bat -e '$COMMAND'"

--- a/.github/workflows/standalone-test.yml
+++ b/.github/workflows/standalone-test.yml
@@ -93,6 +93,11 @@ jobs:
                       mvn test -q -Dtest=ExportFileIT#checkExportCsv -DfailIfNoTests=false -P-format
                   fi
 
+            - name: Stop IGinX and ZK, Clear ZK Data, then Start Them
+              uses: ./.github/actions/context
+              with:
+                  work-name: restart-iginx-zk
+
             - name: set client test context
               uses: ./.github/actions/context
               with:

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/InsertGenerator.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/InsertGenerator.java
@@ -16,6 +16,7 @@ import cn.edu.tsinghua.iginx.metadata.IMetaManager;
 import cn.edu.tsinghua.iginx.metadata.entity.*;
 import cn.edu.tsinghua.iginx.policy.IPolicy;
 import cn.edu.tsinghua.iginx.policy.PolicyManager;
+import cn.edu.tsinghua.iginx.policy.Utils;
 import cn.edu.tsinghua.iginx.sql.statement.InsertStatement;
 import cn.edu.tsinghua.iginx.sql.statement.Statement;
 import cn.edu.tsinghua.iginx.utils.Pair;
@@ -48,7 +49,7 @@ public class InsertGenerator extends AbstractGenerator {
 
     policy.notify(insertStatement);
 
-    List<String> pathList = new ArrayList<>(insertStatement.getPaths());
+    List<String> pathList = Utils.getPathListFromStatement(insertStatement);
 
     ColumnsInterval columnsInterval =
         new ColumnsInterval(pathList.get(0), pathList.get(pathList.size() - 1));

--- a/core/src/main/java/cn/edu/tsinghua/iginx/policy/Utils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/policy/Utils.java
@@ -17,7 +17,7 @@ public class Utils {
     List<String> retVal = Collections.emptyList();
     switch (statement.getType()) {
       case SELECT:
-        retVal =  new ArrayList<>(((SelectStatement) statement).getPathSet());
+        retVal = new ArrayList<>(((SelectStatement) statement).getPathSet());
         break;
       case DELETE:
         retVal = ((DeleteStatement) statement).getPaths();
@@ -29,8 +29,7 @@ public class Utils {
         // TODO: case label. should we return empty list for other statements?
         break;
     }
-    if(!retVal.isEmpty())
-      Collections.sort(retVal);
+    if (!retVal.isEmpty()) Collections.sort(retVal);
     return retVal;
   }
 
@@ -66,7 +65,8 @@ public class Utils {
       case INSERT:
         InsertStatement insertStatement = (InsertStatement) statement;
         List<Long> keys = insertStatement.getKeys();
-        return new KeyInterval(Collections.min(keys), Collections.min(keys));//interval should require coparison
+        return new KeyInterval(
+            Collections.min(keys), Collections.min(keys)); // interval should require coparison
       case SELECT:
         UnarySelectStatement selectStatement = (UnarySelectStatement) statement;
         return new KeyInterval(selectStatement.getStartKey(), selectStatement.getEndKey());

--- a/core/src/main/java/cn/edu/tsinghua/iginx/policy/Utils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/policy/Utils.java
@@ -14,18 +14,24 @@ import java.util.*;
 public class Utils {
 
   public static List<String> getPathListFromStatement(DataStatement statement) {
+    List<String> retVal = Collections.emptyList();
     switch (statement.getType()) {
       case SELECT:
-        return new ArrayList<>(((SelectStatement) statement).getPathSet());
+        retVal =  new ArrayList<>(((SelectStatement) statement).getPathSet());
+        break;
       case DELETE:
-        return ((DeleteStatement) statement).getPaths();
+        retVal = ((DeleteStatement) statement).getPaths();
+        break;
       case INSERT:
-        return ((InsertStatement) statement).getPaths();
+        retVal = ((InsertStatement) statement).getPaths();
+        break;
       default:
         // TODO: case label. should we return empty list for other statements?
         break;
     }
-    return Collections.emptyList();
+    if(!retVal.isEmpty())
+      Collections.sort(retVal);
+    return retVal;
   }
 
   public static List<String> getNonWildCardPaths(List<String> paths) {
@@ -60,7 +66,7 @@ public class Utils {
       case INSERT:
         InsertStatement insertStatement = (InsertStatement) statement;
         List<Long> keys = insertStatement.getKeys();
-        return new KeyInterval(keys.get(0), keys.get(keys.size() - 1));
+        return new KeyInterval(Collections.min(keys), Collections.min(keys));//interval should require coparison
       case SELECT:
         UnarySelectStatement selectStatement = (UnarySelectStatement) statement;
         return new KeyInterval(selectStatement.getStartKey(), selectStatement.getEndKey());


### PR DESCRIPTION
Fix the following bug:
1. Using "LOAD DATA FROM INFILE "csvFile.csv" AS CSV SKIPPING HEADER INTO test.table(key, col1, col2, col3);" as the first command after IGinX starts, data cannot be properly inserted.
2. Making a select before the above load statement, everything is correct.

Problem:
Path list is not properly sorted for metadata generation and query.

Solution:
Sort the list
What is also added is the test to expose the corresponding problem