### PR TITLE
fix(core): response success and spin for IStorage when init of storag…

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -19,9 +19,7 @@
 package cn.edu.tsinghua.iginx;
 
 import static cn.edu.tsinghua.iginx.metadata.utils.IdUtils.generateDummyStorageUnitId;
-import static cn.edu.tsinghua.iginx.metadata.utils.StorageEngineUtils.checkEmbeddedStorageExtraParams;
-import static cn.edu.tsinghua.iginx.metadata.utils.StorageEngineUtils.isEmbeddedStorageEngine;
-import static cn.edu.tsinghua.iginx.metadata.utils.StorageEngineUtils.isLocal;
+import static cn.edu.tsinghua.iginx.metadata.utils.StorageEngineUtils.*;
 import static cn.edu.tsinghua.iginx.utils.ByteUtils.getLongArrayFromByteBuffer;
 import static cn.edu.tsinghua.iginx.utils.HostUtils.isLocalHost;
 import static cn.edu.tsinghua.iginx.utils.HostUtils.isValidHost;
@@ -39,6 +37,7 @@ import cn.edu.tsinghua.iginx.engine.physical.PhysicalEngineImpl;
 import cn.edu.tsinghua.iginx.engine.physical.storage.IStorage;
 import cn.edu.tsinghua.iginx.engine.physical.storage.StorageManager;
 import cn.edu.tsinghua.iginx.engine.shared.RequestContext;
+import cn.edu.tsinghua.iginx.exception.StatusCode;
 import cn.edu.tsinghua.iginx.metadata.DefaultMetaManager;
 import cn.edu.tsinghua.iginx.metadata.IMetaManager;
 import cn.edu.tsinghua.iginx.metadata.entity.*;
@@ -46,7 +45,6 @@ import cn.edu.tsinghua.iginx.resource.QueryResourceManager;
 import cn.edu.tsinghua.iginx.thrift.*;
 import cn.edu.tsinghua.iginx.transform.exec.TransformJobManager;
 import cn.edu.tsinghua.iginx.utils.*;
-import cn.edu.tsinghua.iginx.utils.JsonUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -457,12 +455,19 @@ public class IginxWorker implements IService.Iface {
     }
 
     StorageManager storageManager = PhysicalEngineImpl.getInstance().getStorageManager();
-    if (!metaManager.addStorageEngines(otherMetas)) {
-      logger.error("add storage engines failed.");
-      status.addToSubStatus(RpcUtils.FAILURE);
-    }
     for (StorageEngineMeta meta : otherMetas) {
-      storageManager.addStorage(meta);
+      IStorage storage = storageManager.initRemoteStorage(meta);
+      if (storage == null) {
+        status.addToSubStatus(
+            RpcUtils.status(StatusCode.STATEMENT_EXECUTION_ERROR, "init storage engine failed"));
+        continue;
+      }
+      if (!metaManager.addStorageEngines(Collections.singletonList(meta))) {
+        logger.error("add storage engine {} failed.", meta);
+        status.addToSubStatus(RpcUtils.FAILURE);
+        continue;
+      }
+      storageManager.addStorage(meta, storage);
     }
     for (StorageEngineMeta meta : localMetas) {
       IStorage storage = storageManager.initLocalStorage(meta);

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
@@ -18,8 +18,6 @@
  */
 package cn.edu.tsinghua.iginx.engine.physical.storage;
 
-import static cn.edu.tsinghua.iginx.metadata.utils.StorageEngineUtils.isEmbeddedStorageEngine;
-
 import cn.edu.tsinghua.iginx.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iginx.metadata.entity.ColumnsInterval;
 import cn.edu.tsinghua.iginx.metadata.entity.KeyInterval;
@@ -199,23 +197,7 @@ public class StorageManager {
     return true;
   }
 
-  public IStorage initLocalStorage(StorageEngineMeta meta) {
-    StorageEngineType engine = meta.getStorageEngine();
-    if (!isEmbeddedStorageEngine(engine)) {
-      return null;
-    }
-    return createStorageInstance(meta);
-  }
-
-  public IStorage initRemoteStorage(StorageEngineMeta meta) {
-    StorageEngineType engine = meta.getStorageEngine();
-    if (isEmbeddedStorageEngine(engine)) {
-      return null;
-    }
-    return createStorageInstance(meta);
-  }
-
-  private IStorage createStorageInstance(StorageEngineMeta meta) {
+  public static IStorage initStorageInstance(StorageEngineMeta meta) {
     StorageEngineType engine = meta.getStorageEngine();
     String driver = drivers.get(engine);
     ClassLoader loader = classLoaders.get(engine);

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
@@ -204,6 +204,19 @@ public class StorageManager {
     if (!isEmbeddedStorageEngine(engine)) {
       return null;
     }
+    return createStorageInstance(meta);
+  }
+
+  public IStorage initRemoteStorage(StorageEngineMeta meta) {
+    StorageEngineType engine = meta.getStorageEngine();
+    if (isEmbeddedStorageEngine(engine)) {
+      return null;
+    }
+    return createStorageInstance(meta);
+  }
+
+  private IStorage createStorageInstance(StorageEngineMeta meta) {
+    StorageEngineType engine = meta.getStorageEngine();
     String driver = drivers.get(engine);
     ClassLoader loader = classLoaders.get(engine);
     try {


### PR DESCRIPTION
### BUG 复现及效果

1. 以 parquet 作为初始存储引擎启动IGinX
2. 删除 postgresql 的 driver 文件，即删除 `driver/postgresql` 文件夹
3. 在命令行客户端执行 `add storageengine("101.6.15.203",65432,"postgresql","username:postgre,password:123456,has_data:true");`
4. 客户端返回执行成功 
5. IGinX 无限循环打印错误日志 `spinning for IStorage！`

### 原因分析

执行 `add storageengine` 时没有检查存储引擎是否初始化成功，导致始终返回给客户端成功信息。

在存储引擎是否初始化失败的情况下，在 `StorageManager` 没有相关实例对象，后续操作中异步线程会循环地尝试从 `StorageManager` 中获取该对象，由于获取不到，导致无限循环。

### 解决方式

检查存储引擎是否初始化成功，并避免在错误状态下继续执行后续逻辑。




