### PR TITLE
docs: use relative path in Markdown document

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ IGinX (Intelligent enGine X) aims to facilitate users in profiting from their da
 
 ## Installation
 
-See the [getting started](https://github.com/IGinX-THU/IGinX/blob/main/docs/getting_started.md) documentation to start a IGinX in various ways.
+See the [getting started](./docs/getting_started.md) documentation to start a IGinX in various ways.
 
 ## Team and Contributions
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,5 +8,5 @@ You can run IGinX in the following ways:
 
 The complete quick start can be found here-[完整版部署说明文档](./quickStarts/IGinXManual.md) in Chinese and here-[IGinX Installation and Use Manual](./quickStarts/IGinXManual-EnglishVersion.md) in English.
 
-Or, please refer to our [User manual in Chinese - 中文用户手册](https://github.com/IGinX-THU/IGinX/raw/main/docs/pdf/userManualC.pdf). User manuals in English are
+Or, please refer to our [User manual in Chinese - 中文用户手册](./pdf/userManualC.pdf). User manuals in English are
 still being written, but you might contact [THU_IGinX team](mailto:TSIGinX@gmail.com) for IGinX in case of any question or problem.

--- a/docs/quickStarts/IGinXBySource-EnglishVersion.md
+++ b/docs/quickStarts/IGinXBySource-EnglishVersion.md
@@ -412,11 +412,11 @@ The command will return information about the data point just inserted:
 
 If you see the following information returned, it means you are able to successfully use RESTful interface to write and query data to IGinX.
 
-For more interfaces, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+For more interfaces, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 If you want to use a different interface, there is another option.
 
-In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 At the same time, IGinX also provides some official examples, showing the most common usage of the RPC interface.
 

--- a/docs/quickStarts/IGinXBySource.md
+++ b/docs/quickStarts/IGinXBySource.md
@@ -410,12 +410,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts/IGinXCluster-EnglishVersion.md
+++ b/docs/quickStarts/IGinXCluster-EnglishVersion.md
@@ -333,7 +333,7 @@ For more interfaces, please refer to the official IGinX manual.
 
 ### RPC Interface
 
-In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
+In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](../pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
 
 Below is a short tutorial on how to use it.
 

--- a/docs/quickStarts/IGinXCluster.md
+++ b/docs/quickStarts/IGinXCluster.md
@@ -333,12 +333,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts/IGinXInOneShot-EnglishVersion.md
+++ b/docs/quickStarts/IGinXInOneShot-EnglishVersion.md
@@ -239,11 +239,11 @@ The command will return information about the data point just inserted:
 
 If you see the following information returned, it means you are able to successfully use RESTful interface to write and query data to IGinX.
 
-For more interfaces, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+For more interfaces, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 If you want to use a different interface, there is another option.
 
-In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 At the same time, IGinX also provides some official examples, showing the most common usage of the RPC interface.
 

--- a/docs/quickStarts/IGinXInOneShot.md
+++ b/docs/quickStarts/IGinXInOneShot.md
@@ -236,12 +236,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts/IGinXManual-EnglishVersion.md
+++ b/docs/quickStarts/IGinXManual-EnglishVersion.md
@@ -476,11 +476,11 @@ The command will return information about the data point just inserted:
 }
 ```
 
-For more interfaces, please refer to [IGinX Official Manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+For more interfaces, please refer to [IGinX Official Manual](../pdf/userManualC.pdf).
 
 ### RPC Interface
 
-In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
+In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](../pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
 
 Below is a short tutorial on how to use it.
 

--- a/docs/quickStarts/IGinXManual.md
+++ b/docs/quickStarts/IGinXManual.md
@@ -474,12 +474,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts_Parquet/IGinXBySource-EnglishVersion.md
+++ b/docs/quickStarts_Parquet/IGinXBySource-EnglishVersion.md
@@ -384,11 +384,11 @@ The command will return information about the data point just inserted:
 
 If you see the following information returned, it means you are able to successfully use RESTful interface to write and query data to IGinX.
 
-For more interfaces, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+For more interfaces, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 If you want to use a different interface, there is another option.
 
-In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 At the same time, IGinX also provides some official examples, showing the most common usage of the RPC interface.
 

--- a/docs/quickStarts_Parquet/IGinXBySource.md
+++ b/docs/quickStarts_Parquet/IGinXBySource.md
@@ -384,12 +384,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts_Parquet/IGinXCluster-EnglishVersion.md
+++ b/docs/quickStarts_Parquet/IGinXCluster-EnglishVersion.md
@@ -299,7 +299,7 @@ For more interfaces, please refer to the official IGinX manual.
 
 ### RPC Interface
 
-In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
+In addition to the RESTful interface, IGinX also provides RPC data access interface. For that specific interface, please refer to the official[IGinX Official Manual](../pdf/userManualC.pdf). At the same time, IGinX also provides some [official examples](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session), showing the most common usage of the RPC interface.
 
 Below is a short tutorial on how to use it.
 

--- a/docs/quickStarts_Parquet/IGinXCluster.md
+++ b/docs/quickStarts_Parquet/IGinXCluster.md
@@ -295,12 +295,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 

--- a/docs/quickStarts_Parquet/IGinXInOneShot-EnglishVersion.md
+++ b/docs/quickStarts_Parquet/IGinXInOneShot-EnglishVersion.md
@@ -221,11 +221,11 @@ The command will return information about the data point just inserted:
 
 If you see the following information returned, it means you are able to successfully use RESTful interface to write and query data to IGinX.
 
-For more interfaces, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+For more interfaces, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 If you want to use a different interface, there is another option.
 
-In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf).
+In addition to the RESTful interface, IGinX also provides the RPC data access interface. For this specific interface, please refer to the official [IGinX manual](../pdf/userManualC.pdf).
 
 At the same time, IGinX also provides some official examples, showing the most common usage of the RPC interface.
 

--- a/docs/quickStarts_Parquet/IGinXInOneShot.md
+++ b/docs/quickStarts_Parquet/IGinXInOneShot.md
@@ -217,12 +217,12 @@ $ curl -XPOST -H'Content-Type: application/json' -d @query.json http://127.0.0.1
 }
 ```
 
-更多接口可以参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf) 。
+更多接口可以参考 [IGinX 官方手册](../pdf/userManualC.pdf) 。
 
 ### RPC 接口
 
 除了 RESTful 接口外，IGinX 还提供了 RPC
-的数据访问接口，具体接口参考 [IGinX 官方手册](https://github.com/IGinX-THU/IGinX/blob/main/docs/pdf/userManualC.pdf)，同时 IGinX
+的数据访问接口，具体接口参考 [IGinX 官方手册](../pdf/userManualC.pdf)，同时 IGinX
 还提供了部分[官方 example](https://github.com/IGinX-THU/IGinX/tree/main/example/src/main/java/cn/edu/tsinghua/iginx/session)，展示了
 RPC 接口最常见的用法。
 


### PR DESCRIPTION
只有使用相对路径，才能在 github pages 以及本地正确跳转，否则会跳转到github仓库文件，而不是 github pages 或本地中的页面。

示例：
https://aqni.github.io/IGinX/

![image](https://github.com/IGinX-THU/IGinX/assets/72963199/bc040d95-9200-4245-b5b1-a97109b6414f)
