### PR TITLE
feat(filesystem): support for redirection when adding file systems

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -350,6 +350,12 @@ public class IginxWorker implements IService.Iface {
         status.addToSubStatus(RpcUtils.FAILURE);
         continue;
       }
+      if (needRedirect(type, extraParams)) {
+        status.setCode(StatusCode.REDIRECT.getStatusCode());
+        status.setMessage(extraParams.get("ip") + ":" + extraParams.get("port"));
+        return status;
+      }
+
       String schemaPrefix = extraParams.get(Constants.SCHEMA_PREFIX);
       StorageEngineMeta meta =
           new StorageEngineMeta(

--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -344,18 +344,18 @@ public class IginxWorker implements IService.Iface {
         status.addToSubStatus(RpcUtils.FAILURE);
         continue;
       }
+      if (needRedirect(type, ip)) {
+        status.setCode(StatusCode.REDIRECT.getStatusCode());
+        status.setMessage(ip + ":" + extraParams.get("iginx_port"));
+        LOGGER.warn("redirect to {}:{}.", ip, extraParams.get("iginx_port"));
+        return status;
+      }
       if (!checkEmbeddedStorageExtraParams(type, extraParams)) {
         LOGGER.error(
             "missing params or providing invalid ones for {} in statement.", storageEngine);
         status.addToSubStatus(RpcUtils.FAILURE);
         continue;
       }
-      if (needRedirect(type, extraParams)) {
-        status.setCode(StatusCode.REDIRECT.getStatusCode());
-        status.setMessage(extraParams.get("ip") + ":" + extraParams.get("port"));
-        return status;
-      }
-
       String schemaPrefix = extraParams.get(Constants.SCHEMA_PREFIX);
       StorageEngineMeta meta =
           new StorageEngineMeta(

--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -339,16 +339,16 @@ public class IginxWorker implements IService.Iface {
         status.addToSubStatus(RpcUtils.FAILURE);
         continue;
       }
-      if (!hasData & readOnly) { // 无意义的存储引擎：不带数据且只读
-        LOGGER.error("normal storage engine {} should not be read-only.", storageEngine);
-        status.addToSubStatus(RpcUtils.FAILURE);
-        continue;
-      }
-      if (needRedirect(type, ip)) {
+      if (isEmbeddedStorageEngine(type) && !isLocalHost(ip)) {
         status.setCode(StatusCode.REDIRECT.getStatusCode());
         status.setMessage(ip + ":" + extraParams.get("iginx_port"));
         LOGGER.warn("redirect to {}:{}.", ip, extraParams.get("iginx_port"));
         return status;
+      }
+      if (!hasData & readOnly) { // 无意义的存储引擎：不带数据且只读
+        LOGGER.error("normal storage engine {} should not be read-only.", storageEngine);
+        status.addToSubStatus(RpcUtils.FAILURE);
+        continue;
       }
       if (!checkEmbeddedStorageExtraParams(type, extraParams)) {
         LOGGER.error(

--- a/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
@@ -33,6 +33,13 @@ public class StorageEngineUtils {
     return file.exists() && file.isDirectory();
   }
 
+  public static boolean needRedirect(StorageEngineType type, Map<String, String> extraParams) {
+    if (type.equals(StorageEngineType.filesystem)) {
+      return !isLocalHost(extraParams.get("ip"));
+    }
+    return false;
+  }
+
   public static boolean checkEmbeddedStorageExtraParams(
       StorageEngineType type, Map<String, String> extraParams) {
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
@@ -33,9 +33,9 @@ public class StorageEngineUtils {
     return file.exists() && file.isDirectory();
   }
 
-  public static boolean needRedirect(StorageEngineType type, Map<String, String> extraParams) {
+  public static boolean needRedirect(StorageEngineType type, String ip) {
     if (type.equals(StorageEngineType.filesystem)) {
-      return !isLocalHost(extraParams.get("ip"));
+      return !isLocalHost(ip);
     }
     return false;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/metadata/utils/StorageEngineUtils.java
@@ -33,13 +33,6 @@ public class StorageEngineUtils {
     return file.exists() && file.isDirectory();
   }
 
-  public static boolean needRedirect(StorageEngineType type, String ip) {
-    if (type.equals(StorageEngineType.filesystem)) {
-      return !isLocalHost(ip);
-    }
-    return false;
-  }
-
   public static boolean checkEmbeddedStorageExtraParams(
       StorageEngineType type, Map<String, String> extraParams) {
 


### PR DESCRIPTION
## 问题
在22节点上添加ip为24的含有dummy_dir的文件系统，报以下错误。

```txt
dataPrefix: null
realDummyRoot: null
parameter: null
2024-05-21 23:41:42,637 [1;31mERROR[m [TThreadPoolServer WorkerProcess-0] - [org.apache.thrift.ProcessFunction.process:47] Internal error processing getBoundaryOfStorage
java.lang.NullPointerException
        at java.io.File.<init>(File.java:279)
        at cn.edu.tsinghua.iginx.filesystem.exec.LocalExecutor.getBoundaryOfStorage(LocalExecutor.java:355)
        at cn.edu.tsinghua.iginx.filesystem.server.FileSystemWorker.getBoundaryOfStorage(FileSystemWorker.java:226)
        at cn.edu.tsinghua.iginx.filesystem.thrift.FileSystemService$Processor$getBoundaryOfStorage.getResult(FileSystemService.java:495)
        at cn.edu.tsinghua.iginx.filesystem.thrift.FileSystemService$Processor$getBoundaryOfStorage.getResult(FileSystemService.java:475)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

## 分析
在22节点上添加ip为24的含有dummy_dir的文件系统时，22节点会在本地启动一个IStorage，但是该IStorage应该在24节点上启动。

## 解决方案
转发该请求到24节点。

![image](https://github.com/IGinX-THU/IGinX/assets/80055724/2b88f2e0-2749-46cb-b386-6a9a20dc667a)
![image](https://github.com/IGinX-THU/IGinX/assets/80055724/58680fae-1a03-43b8-b58a-5ef3e7e52426)
