### PR TITLE
feat(optimizer): distinct eliminate rule

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -52,7 +52,7 @@ maxCachedPhysicalTaskPerStorage=500
 queryOptimizer=rbo
 
 # 优化器规则
-ruleBasedOptimizer=NotFilterRemoveRule=on,FragmentPruningByFilterRule=on,ColumnPruningRule=on,FragmentPruningByPatternRule=on,ConstantPropagationRule=on,FilterConstantFoldingRule=on,RowTransformConstantFoldingRule=on
+ruleBasedOptimizer=NotFilterRemoveRule=on,FragmentPruningByFilterRule=on,ColumnPruningRule=on,FragmentPruningByPatternRule=on,ConstantPropagationRule=on,FilterConstantFoldingRule=on,RowTransformConstantFoldingRule=on,FunctionDistinctEliminateRule=on,InExistsDistinctEliminateRule=on
 
 # ParallelFilter触发行数
 parallelFilterThreshold=10000

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/FunctionDistinctEliminateRule.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/FunctionDistinctEliminateRule.java
@@ -1,0 +1,99 @@
+package cn.edu.tsinghua.iginx.engine.logical.optimizer.rules;
+
+import cn.edu.tsinghua.iginx.engine.logical.optimizer.core.RuleCall;
+import cn.edu.tsinghua.iginx.engine.shared.function.FunctionCall;
+import cn.edu.tsinghua.iginx.engine.shared.function.system.Max;
+import cn.edu.tsinghua.iginx.engine.shared.function.system.Min;
+import cn.edu.tsinghua.iginx.engine.shared.operator.*;
+import cn.edu.tsinghua.iginx.engine.shared.operator.type.OperatorType;
+import cn.edu.tsinghua.iginx.engine.shared.source.OperatorSource;
+import java.util.*;
+
+/** 该类实现了GroupBy节点中函数中的Distinct的消除。该规则用于消除函数中的Distinct，比如在min(distinct a)中的distinct是不必要的。 */
+public class FunctionDistinctEliminateRule extends Rule {
+
+  private static final Set<String> functionSet = new HashSet<>(Arrays.asList(Min.MIN, Max.MAX));
+
+  private static class InstanceHolder {
+    static final FunctionDistinctEliminateRule INSTANCE = new FunctionDistinctEliminateRule();
+  }
+
+  public static FunctionDistinctEliminateRule getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  protected FunctionDistinctEliminateRule() {
+    /*
+     * we want to match the topology like:
+     *     GroupBy/DownSample/Row/Mapping/SetTransform
+     *               |
+     *              Any
+     */
+    super("FunctionDistinctEliminateRule", operand(AbstractUnaryOperator.class, any()));
+  }
+
+  public boolean matches(RuleCall call) {
+    AbstractUnaryOperator unaryOperator = (AbstractUnaryOperator) call.getMatchedRoot();
+
+    if (!OperatorType.isHasFunction(unaryOperator.getType())) {
+      return false;
+    }
+
+    List<FunctionCall> functionCallList = getFunctionCallList(unaryOperator);
+    if (!isDistinct(unaryOperator)) {
+      return false;
+    }
+    if (functionCallList.stream()
+        .anyMatch(
+            functionCall -> !functionSet.contains(functionCall.getFunction().getIdentifier()))) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public void onMatch(RuleCall call) {
+    AbstractUnaryOperator unaryOperator = (AbstractUnaryOperator) call.getMatchedRoot();
+    List<FunctionCall> functionCallList = getFunctionCallList(unaryOperator);
+    Map<String, String> renameMap = new HashMap<>();
+
+    // 将函数中的distinct去掉
+    for (FunctionCall functionCall : functionCallList) {
+      String oldName = functionCall.getFunctionStr();
+      functionCall.getParams().setDistinct(false);
+      renameMap.put(functionCall.getFunctionStr(), oldName);
+    }
+
+    // 添加一个rename节点，将不带distinct的函数结果重命名为原来的函数名，否则显示与用户输入的SQL不一致
+    Rename rename = new Rename(new OperatorSource(unaryOperator), renameMap);
+
+    call.transformTo(rename);
+  }
+
+  private List<FunctionCall> getFunctionCallList(AbstractUnaryOperator unaryOperator) {
+    switch (unaryOperator.getType()) {
+      case GroupBy:
+        return ((GroupBy) unaryOperator).getFunctionCallList();
+      case Downsample:
+        return ((Downsample) unaryOperator).getFunctionCallList();
+      case RowTransform:
+        return ((RowTransform) unaryOperator).getFunctionCallList();
+      case MappingTransform:
+        return ((MappingTransform) unaryOperator).getFunctionCallList();
+      case SetTransform:
+        return ((SetTransform) unaryOperator).getFunctionCallList();
+      default:
+        return new ArrayList<>();
+    }
+  }
+
+  private boolean isDistinct(AbstractUnaryOperator operator) {
+    List<FunctionCall> functionCallList = getFunctionCallList(operator);
+    for (FunctionCall functionCall : functionCallList) {
+      if (functionCall.getParams().isDistinct()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/InExistsDistinctEliminateRule.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/InExistsDistinctEliminateRule.java
@@ -1,0 +1,64 @@
+package cn.edu.tsinghua.iginx.engine.logical.optimizer.rules;
+
+import cn.edu.tsinghua.iginx.engine.logical.optimizer.core.RuleCall;
+import cn.edu.tsinghua.iginx.engine.shared.operator.AbstractJoin;
+import cn.edu.tsinghua.iginx.engine.shared.operator.Distinct;
+import cn.edu.tsinghua.iginx.engine.shared.operator.Operator;
+import cn.edu.tsinghua.iginx.engine.shared.operator.type.OperatorType;
+
+/**
+ * 该类实现了Distinct节点的消除。该规则用于消除IN/EXISTS子查询中的DISTINCT节点， 例如SELECT * FROM t1 WHERE EXISTS (SELECT
+ * DISTINCT * FROM t2 WHERE t1.a = t2.a)，这里面的DISTINCT节点其实是不必要的。
+ */
+public class InExistsDistinctEliminateRule extends Rule {
+  private static class InstanceHolder {
+    static final InExistsDistinctEliminateRule INSTANCE = new InExistsDistinctEliminateRule();
+  }
+
+  public static InExistsDistinctEliminateRule getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  protected InExistsDistinctEliminateRule() {
+    /*
+     * we want to match the topology like:
+     *             MarkJoin
+     *           /         \
+     *          ...        ...
+     *                      |
+     *                   Distinct
+     *                      |
+     *                     Any
+     */
+    super("InExistsDistinctEliminateRule", operand(Distinct.class, any()));
+  }
+
+  public boolean matches(RuleCall call) {
+    // 向上找到MarkJoin节点，只有第一个Join节点是MarkJoin节点才能进行Distinct消除
+    Distinct distinct = (Distinct) call.getMatchedRoot();
+    Operator operator = findUpFirstJoin(call, distinct);
+    return operator != null && operator.getType() == OperatorType.MarkJoin;
+  }
+
+  public void onMatch(RuleCall call) {
+    // 把Distinct节点消除，替换为其子节点
+    Distinct distinct = (Distinct) call.getMatchedRoot();
+    call.transformTo(call.getChildrenIndex().get(distinct).get(0));
+  }
+
+  /**
+   * 向上找到第一个Join节点
+   *
+   * @param operator 给定当前节点
+   * @return 如果找到了，返回Join节点，否则返回null
+   */
+  private AbstractJoin findUpFirstJoin(RuleCall ruleCall, Operator operator) {
+    if (operator == null) {
+      return null;
+    } else if (OperatorType.isJoinOperator(operator.getType())) {
+      return (AbstractJoin) operator;
+    } else {
+      return findUpFirstJoin(ruleCall, ruleCall.getParentIndexMap().getOrDefault(operator, null));
+    }
+  }
+}

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/RuleCollection.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/optimizer/rules/RuleCollection.java
@@ -34,6 +34,8 @@ public class RuleCollection {
     addRule(ConstantPropagationRule.getInstance());
     addRule(FilterConstantFoldingRule.getInstance());
     addRule(RowTransformConstantFoldingRule.getInstance());
+    addRule(FunctionDistinctEliminateRule.getInstance());
+    addRule(InExistsDistinctEliminateRule.getInstance());
     setRulesByConfig();
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/FunctionCall.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/FunctionCall.java
@@ -18,6 +18,11 @@
  */
 package cn.edu.tsinghua.iginx.engine.shared.function;
 
+import cn.edu.tsinghua.iginx.engine.shared.function.system.ArithmeticExpr;
+import cn.edu.tsinghua.iginx.engine.shared.function.udf.UDAF;
+import cn.edu.tsinghua.iginx.engine.shared.function.udf.UDSF;
+import cn.edu.tsinghua.iginx.engine.shared.function.udf.UDTF;
+
 public class FunctionCall {
 
   private final Function function;
@@ -46,6 +51,35 @@ public class FunctionCall {
     return String.format(
         "{Name: %s, FuncType: %s, MappingType: %s}",
         function.getIdentifier(), function.getFunctionType(), function.getMappingType());
+  }
+
+  private String getFuncName() {
+    if (function instanceof ArithmeticExpr) {
+      return params.getExpr().getColumnName();
+    } else if (function.getFunctionType() == FunctionType.UDF) {
+      if (function instanceof UDAF) {
+        return ((UDAF) function).getFunctionName();
+      } else if (function instanceof UDTF) {
+        return ((UDTF) function).getFunctionName();
+      } else if (function instanceof UDSF) {
+        return ((UDSF) function).getFunctionName();
+      }
+    } else {
+      return function.getIdentifier();
+    }
+    return null;
+  }
+
+  public String getFunctionStr() {
+    if (function instanceof ArithmeticExpr) {
+      return params.getExpr().getColumnName();
+    }
+
+    return String.format(
+        "%s(%s%s)",
+        getFuncName(),
+        params.isDistinct() ? "distinct " : "",
+        String.join(", ", params.getPaths()));
   }
 
   public String getNameAndFuncTypeStr() {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/FunctionParams.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/FunctionParams.java
@@ -16,7 +16,7 @@ public class FunctionParams {
 
   private Expression expr;
 
-  private final boolean isDistinct;
+  private boolean isDistinct;
 
   public FunctionParams(List<String> paths) {
     this(paths, null, null, null, false);
@@ -70,6 +70,10 @@ public class FunctionParams {
 
   public boolean isDistinct() {
     return isDistinct;
+  }
+
+  public void setDistinct(boolean distinct) {
+    isDistinct = distinct;
   }
 
   protected FunctionParams copy() {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/GroupBy.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/GroupBy.java
@@ -40,6 +40,14 @@ public class GroupBy extends AbstractUnaryOperator {
     return new GroupBy(source, new ArrayList<>(groupByCols), new ArrayList<>(functionCallList));
   }
 
+  public boolean isDistinct() {
+    // 所有的functionCall的distinct属性都相同，所以只需要看第一个就可以了
+    if (functionCallList.size() > 0) {
+      return functionCallList.get(0).getParams().isDistinct();
+    }
+    return false;
+  }
+
   @Override
   public String getInfo() {
     StringBuilder builder = new StringBuilder();
@@ -51,6 +59,11 @@ public class GroupBy extends AbstractUnaryOperator {
       }
       builder.append(" MappingType: ");
       builder.append(functionCallList.get(0).getFunction().getMappingType());
+      if (isDistinct()) {
+        builder.append(" isDistinct: true");
+      } else {
+        builder.append(" isDistinct: false");
+      }
     }
     return builder.toString();
   }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
@@ -6609,19 +6609,19 @@ public class SQLSessionIT {
             new Pair<>(
                 "EXPLAIN SELECT avg(bb) FROM (SELECT a as aa, b as bb FROM us.d2) WHERE key > 2 GROUP BY aa;",
                 "ResultSets:\n"
-                    + "+------------------------+-------------+---------------------------------------------------------------------------------+\n"
-                    + "|            Logical Tree|Operator Type|                                                                    Operator Info|\n"
-                    + "+------------------------+-------------+---------------------------------------------------------------------------------+\n"
-                    + "|Reorder                 |      Reorder|                                                                   Order: avg(bb)|\n"
-                    + "|  +--GroupBy            |      GroupBy|GroupByCols: aa, FuncList(Name, FuncType): (avg, System), MappingType: SetMapping|\n"
-                    + "|    +--Select           |       Select|                                                                  Filter: key > 2|\n"
-                    + "|      +--Rename         |       Rename|                                            AliasMap: (us.d2.a, aa),(us.d2.b, bb)|\n"
-                    + "|        +--Reorder      |      Reorder|                                                           Order: us.d2.a,us.d2.b|\n"
-                    + "|          +--Project    |      Project|                                                        Patterns: us.d2.a,us.d2.b|\n"
-                    + "|            +--PathUnion|    PathUnion|                                                                                 |\n"
-                    + "|              +--Project|      Project|                             Patterns: us.d2.a,us.d2.b, Target DU: unit0000000002|\n"
-                    + "|              +--Project|      Project|                             Patterns: us.d2.a,us.d2.b, Target DU: unit0000000003|\n"
-                    + "+------------------------+-------------+---------------------------------------------------------------------------------+\n"
+                    + "+------------------------+-------------+---------------------------------------------------------------------------------------------------+\n"
+                    + "|            Logical Tree|Operator Type|                                                                                      Operator Info|\n"
+                    + "+------------------------+-------------+---------------------------------------------------------------------------------------------------+\n"
+                    + "|Reorder                 |      Reorder|                                                                                     Order: avg(bb)|\n"
+                    + "|  +--GroupBy            |      GroupBy|GroupByCols: aa, FuncList(Name, FuncType): (avg, System), MappingType: SetMapping isDistinct: false|\n"
+                    + "|    +--Select           |       Select|                                                                                    Filter: key > 2|\n"
+                    + "|      +--Rename         |       Rename|                                                              AliasMap: (us.d2.a, aa),(us.d2.b, bb)|\n"
+                    + "|        +--Reorder      |      Reorder|                                                                             Order: us.d2.a,us.d2.b|\n"
+                    + "|          +--Project    |      Project|                                                                          Patterns: us.d2.a,us.d2.b|\n"
+                    + "|            +--PathUnion|    PathUnion|                                                                                                   |\n"
+                    + "|              +--Project|      Project|                                               Patterns: us.d2.a,us.d2.b, Target DU: unit0000000002|\n"
+                    + "|              +--Project|      Project|                                               Patterns: us.d2.a,us.d2.b, Target DU: unit0000000003|\n"
+                    + "+------------------------+-------------+---------------------------------------------------------------------------------------------------+\n"
                     + "Total line number = 9\n"));
 
     // 这里的测例是filter_fragment能处理的节点，开关会导致变化

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
@@ -7571,7 +7571,7 @@ public class SQLSessionIT {
     assertFalse(executor.execute("EXPLAIN " + statement).contains("Distinct"));
     assertEquals(closeResult, executor.execute(statement));
 
-    statement = "SELECT * FROM us.d1 WHERE s1 IN (SELECT DISTINCT s1 FROM us.d1);";
+    statement = "SELECT * FROM us.d1 WHERE s1 IN (SELECT DISTINCT s1 FROM us.d2);";
     executor.execute(closeRule);
     assertTrue(executor.execute("EXPLAIN " + statement).contains("Distinct"));
     closeResult = executor.execute(statement);

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
@@ -6575,17 +6575,17 @@ public class SQLSessionIT {
             new Pair<>(
                 "explain SELECT * FROM (SELECT max(s2), min(s3), s1 FROM us.d1 GROUP BY s1) WHERE us.d1.s1 < 10 AND max(us.d1.s2) > 10;",
                 "ResultSets:\n"
-                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------+\n"
-                    + "|          Logical Tree|Operator Type|                                                                                        Operator Info|\n"
-                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------+\n"
-                    + "|Reorder               |      Reorder|                                                                                             Order: *|\n"
-                    + "|  +--Project          |      Project|                                                                                          Patterns: *|\n"
-                    + "|    +--Reorder        |      Reorder|                                                          Order: max(us.d1.s2),min(us.d1.s3),us.d1.s1|\n"
-                    + "|      +--Select       |       Select|                                                                         Filter: (max(us.d1.s2) > 10)|\n"
-                    + "|        +--GroupBy    |      GroupBy|GroupByCols: us.d1.s1, FuncList(Name, FuncType): (min, System),(max, System), MappingType: SetMapping|\n"
-                    + "|          +--Select   |       Select|                                                                              Filter: (us.d1.s1 < 10)|\n"
-                    + "|            +--Project|      Project|                                      Patterns: us.d1.s1,us.d1.s2,us.d1.s3, Target DU: unit0000000000|\n"
-                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------+\n"
+                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------------------------+\n"
+                    + "|          Logical Tree|Operator Type|                                                                                                          Operator Info|\n"
+                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------------------------+\n"
+                    + "|Reorder               |      Reorder|                                                                                                               Order: *|\n"
+                    + "|  +--Project          |      Project|                                                                                                            Patterns: *|\n"
+                    + "|    +--Reorder        |      Reorder|                                                                            Order: max(us.d1.s2),min(us.d1.s3),us.d1.s1|\n"
+                    + "|      +--Select       |       Select|                                                                                           Filter: (max(us.d1.s2) > 10)|\n"
+                    + "|        +--GroupBy    |      GroupBy|GroupByCols: us.d1.s1, FuncList(Name, FuncType): (min, System),(max, System), MappingType: SetMapping isDistinct: false|\n"
+                    + "|          +--Select   |       Select|                                                                                                Filter: (us.d1.s1 < 10)|\n"
+                    + "|            +--Project|      Project|                                                        Patterns: us.d1.s1,us.d1.s2,us.d1.s3, Target DU: unit0000000000|\n"
+                    + "+----------------------+-------------+-----------------------------------------------------------------------------------------------------------------------+\n"
                     + "Total line number = 7\n"),
             new Pair<>(
                 "explain SELECT * FROM (SELECT avg(s2), count(s3) FROM us.d1) WHERE avg(us.d1.s2) < 10;",


### PR DESCRIPTION
实现了distinct eliminate规则，能够在保证正确性的情况下消除一些不必要的DISTINCT算子，能消除的情况如下：
1. In或EXISTS子查询中的DISTINCT
2. max或min函数中的DISTINCT

上述distinct处理是不必要的，会增加额外开销。

详细描述和测试结果见：[【PR文档】feat(optimizer): distinct eliminate rule](https://oxlh5mrwi0.feishu.cn/wiki/RhWqwNiKNiCpbok6Yxxc4XJjnph)