### PR TITLE
chore: rename postgresql to relational & compare numbers correctly in bat startup script

### DIFF
--- a/assembly/src/assembly/component/iginx-relational-driver.xml
+++ b/assembly/src/assembly/component/iginx-relational-driver.xml
@@ -19,13 +19,13 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>cn.edu.tsinghua:postgresql</include>
+                <include>cn.edu.tsinghua:relational</include>
             </includes>
             <sources>
                 <includeModuleDirectory>false</includeModuleDirectory>
                 <fileSets>
                     <fileSet>
-                        <directory>${project.build.directory}/postgresql-${project.version}</directory>
+                        <directory>${project.build.directory}/relational-${project.version}</directory>
                         <outputDirectory>/</outputDirectory>
                     </fileSet>
                 </fileSets>

--- a/assembly/src/assembly/server.xml
+++ b/assembly/src/assembly/server.xml
@@ -28,7 +28,7 @@
         <componentDescriptor>src/assembly/component/iginx-iotdb12-driver.xml</componentDescriptor>
         <componentDescriptor>src/assembly/component/iginx-mongodb-driver.xml</componentDescriptor>
         <componentDescriptor>src/assembly/component/iginx-parquet-driver.xml</componentDescriptor>
-        <componentDescriptor>src/assembly/component/iginx-postgresql-driver.xml</componentDescriptor>
+        <componentDescriptor>src/assembly/component/iginx-relational-driver.xml</componentDescriptor>
         <componentDescriptor>src/assembly/component/iginx-redis-driver.xml</componentDescriptor>
     </componentDescriptors>
 </assembly>

--- a/core/src/assembly/resources/sbin/start_iginx.bat
+++ b/core/src/assembly/resources/sbin/start_iginx.bat
@@ -99,7 +99,7 @@ set /a quarter_=%half_%/8
 @REM if ["%half_%"] GTR ["1024"] set half_=1024
 @REM if ["%quarter_%"] GTR ["8192"] set quarter_=8192
 
-if ["%half_%"] GTR ["quarter_"] (
+if %half_% GTR %quarter_% (
 	set max_heap_size_in_mb=%half_%
 ) else set max_heap_size_in_mb=%quarter_%
 


### PR DESCRIPTION
上次将 postgresql 改为 relational 时，没有在 assembly 模块同步修改，这次一并修改。

修复 windows 下 iginx 启动脚本，原比较方式 `if ["%half_%"] GTR ["quarter_"]` 有两个错误：

1. "quarter_" 应当改为 %quarter_%，否则比较的是字符串 `quarter_` 本身，而是不是变量 `quarter_` 的值。
2. 应当使用 `if %half_% GTR %quarter_%` 方式比较，否则会当作字符串比较，而不是数字比较。