### PR TITLE
feat(mongodb): don't repeat non-array dummy data

### DIFF
--- a/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/dummy/ResultRow.java
+++ b/dataSources/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/dummy/ResultRow.java
@@ -28,7 +28,7 @@ class ResultRow {
       Map<List<String>, ResultColumn.Builder> builders, long index, List<String> prefix) {
     int maxArraySize = fillArraysInto(builders, index, prefix);
     int insertedRowsNum = Integer.max(maxArraySize, 1);
-    fillFieldsInto(builders, index, prefix, insertedRowsNum);
+    fillFieldsInto(builders, index, prefix, 1);
 
     return insertedRowsNum;
   }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/mongodb/MongoDBCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/mongodb/MongoDBCapacityExpansionIT.java
@@ -85,6 +85,21 @@ public class MongoDBCapacityExpansionIT extends BaseCapacityExpansionIT {
             + "Total line number = 3\n";
     SQLTestTools.executeAndCompare(session, statement, expect);
 
+    // unwind array
+    statement = "select information.contributor, objects.geometryType from d0.c0;";
+    expect =
+        "ResultSets:\n"
+            + "+-----------+-----------------------------+--------------------------+\n"
+            + "|        key|d0.c0.information.contributor|d0.c0.objects.geometryType|\n"
+            + "+-----------+-----------------------------+--------------------------+\n"
+            + "| 4294967296|                 Label Studio|                    bitmap|\n"
+            + "| 4294967297|                         null|                 rectangle|\n"
+            + "| 8589934592|                 Label Studio|                      null|\n"
+            + "|12884901888|                 Label Studio|                      null|\n"
+            + "+-----------+-----------------------------+--------------------------+\n"
+            + "Total line number = 4\n";
+    SQLTestTools.executeAndCompare(session, statement, expect);
+
     // type convert: string -> number
     statement = "select year from d0.c0.information;";
     expect =


### PR DESCRIPTION
对于包含数组的 bson 文档，不重复添加非数组项。