### PR TITLE
fix(core): don't use environment variable to startup iginx

### DIFF
--- a/core/src/assembly/resources/sbin/start_iginx.bat
+++ b/core/src/assembly/resources/sbin/start_iginx.bat
@@ -106,8 +106,8 @@ if %half_% GTR %quarter_% (
 set MAX_HEAP_SIZE=%max_heap_size_in_mb%M
 
 @REM -----------------------------------------------------------------------------
-@REM JVM Opts we'll use in legacy run or installation
 set JAVA_OPTS=-ea^
+ -Dfile.encoding=UTF-8^
  -DIGINX_HOME=%IGINX_HOME%^
  -DIGINX_DRIVER=%IGINX_HOME%\driver^
  -DIGINX_CONF=%IGINX_CONF%
@@ -122,13 +122,7 @@ goto okClasspath
 @REM -----------------------------------------------------------------------------
 :okClasspath
 
-@REM set DRIVER=
-@REM setx DRIVER "%IGINX_HOME%\driver"
-
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% %HEAP_OPTS% -Dfile.encoding=UTF-8 -cp %CLASSPATH% %MAIN_CLASS%
-
-@REM reg delete "HKEY_CURRENT_USER\Environment" /v "DRIVER" /f
-@REM set DRIVER=
+"%JAVA_HOME%\bin\java" %JAVA_OPTS% %HEAP_OPTS% -cp %CLASSPATH% %MAIN_CLASS%
 
 goto finally
 

--- a/core/src/assembly/resources/sbin/start_iginx.sh
+++ b/core/src/assembly/resources/sbin/start_iginx.sh
@@ -121,13 +121,15 @@ HEAP_OPTS[0]=-Xmx$MAX_HEAP_SIZE
 HEAP_OPTS[1]=-Xms$MAX_HEAP_SIZE
 
 # continue to other parameters
-ICONF="$IGINX_HOME/conf/config.properties"
-IDRIVER="$IGINX_HOME/driver/"
+JAVA_OPTS[0]=-ea
+JAVA_OPTS[1]=-Dfile.encoding=UTF-8
+JAVA_OPTS[2]=-Duser.timezone=GMT+8
+JAVA_OPTS[3]=-DIGINX_HOME=$IGINX_HOME
+JAVA_OPTS[4]=-DIGINX_DRIVER="$IGINX_HOME/driver/"
+JAVA_OPTS[5]=-DIGINX_CONF="$IGINX_HOME/conf/config.properties"
 
-export IGINX_CONF=$ICONF
-export IGINX_DRIVER=$IDRIVER
 
-exec "$JAVA" -Duser.timezone=GMT+8 ${HEAP_OPTS[@]} -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+exec "$JAVA" ${JAVA_OPTS[@]} ${HEAP_OPTS[@]} -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
 
 # Double quoted to avoid Word Splitting when IFS contains digit
 exit "$?"

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/utils/EnvUtils.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/utils/EnvUtils.java
@@ -26,11 +26,7 @@ public class EnvUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(EnvUtils.class);
 
   public static boolean loadEnv(String name, boolean defaultValue) {
-    String env = System.getProperty(name);
-    env = env == null ? System.getenv(name) : env;
-    if (env == null) {
-      return defaultValue;
-    }
+    String env = loadEnv(name, String.valueOf(defaultValue));
     try {
       return Boolean.parseBoolean(env);
     } catch (NumberFormatException e) {
@@ -40,11 +36,7 @@ public class EnvUtils {
   }
 
   public static long loadEnv(String name, long defaultValue) {
-    String env = System.getProperty(name);
-    env = env == null ? System.getenv(name) : env;
-    if (env == null) {
-      return defaultValue;
-    }
+    String env = loadEnv(name, String.valueOf(defaultValue));
     try {
       return Long.parseLong(env);
     } catch (NumberFormatException e) {
@@ -54,11 +46,7 @@ public class EnvUtils {
   }
 
   public static int loadEnv(String name, int defaultValue) {
-    String env = System.getProperty(name);
-    env = env == null ? System.getenv(name) : env;
-    if (env == null) {
-      return defaultValue;
-    }
+    String env = loadEnv(name, String.valueOf(defaultValue));
     try {
       return Integer.parseInt(env);
     } catch (NumberFormatException e) {
@@ -68,11 +56,7 @@ public class EnvUtils {
   }
 
   public static double loadEnv(String name, double defaultValue) {
-    String env = System.getProperty(name);
-    env = env == null ? System.getenv(name) : env;
-    if (env == null) {
-      return defaultValue;
-    }
+    String env = loadEnv(name, String.valueOf(defaultValue));
     try {
       return Double.parseDouble(env);
     } catch (NumberFormatException e) {
@@ -97,7 +81,6 @@ public class EnvUtils {
 
   public static String loadEnv(String name, String defaultValue) {
     String env = System.getProperty(name);
-    env = env == null ? System.getenv(name) : env;
     if (env == null) {
       return defaultValue;
     }


### PR DESCRIPTION
在IDEA中调试时不再添加环境变量，而是添加命令行参数
```
-DIGINX_HOME="$IGINX_HOME"
-DIGINX_DRIVER="$IGINX_HOME/driver/"
-DIGINX_CONF="$IGINX_HOME/conf/config.properties"
```
请将$IGINX_HOME替替换为具体值