### PR TITLE
fix(redis): clear data timeout

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -23,7 +23,7 @@ storageEngineList=127.0.0.1#6667#iotdb12#username=root#password=root#sessionPool
 #storageEngineList=127.0.0.1#6667#parquet#dir=/path/to/your/parquet#dummy_dir=/path/to/your/data#iginx_port=6888#has_data=false#is_read_only=false#thrift_timeout=30000#thrift_pool_max_size=100#thrift_pool_min_evictable_idle_time_millis=600000#write.buffer.size=104857600#write.batch.size=1048576#compact.permits=16#cache.capacity=1073741824#parquet.block.size=134217728#parquet.page.size=8192#parquet.compression=SNAPPY
 #storageEngineList=127.0.0.1#27017#mongodb#has_data=false#schema.sample.size=1000#dummy.sample.size=0
 #storageEngineList=127.0.0.1#6667#filesystem#dir=/path/to/your/filesystem#dummy_dir=/path/to/your/data#iginx_port=6888#chunk_size_in_bytes=1048576#memory_pool_size=100#has_data=false#is_read_only=false#thrift_timeout=5000#thrift_pool_max_size=100#thrift_pool_min_evictable_idle_time_millis=600000
-#storageEngineList=127.0.0.1#6379#redis#has_data=false#is_read_only=false#timeout=5000#data_db=1#dummy_db=0
+#storageEngineList=127.0.0.1#6379#redis#has_data=false#is_read_only=false#timeout=10000#data_db=1#dummy_db=0
 
 # UDF定义文件夹存储路径（相对或绝对），文件夹内的文件需要按以下格式进行编写
 # %defaultUDFDir%

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/session/NewSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/session/NewSessionIT.java
@@ -394,7 +394,7 @@ public class NewSessionIT {
 
       List<Long> existsSessionIDs = conn.executeSql("show sessionid;").getSessionIDs();
 
-      if (!new HashSet<>(existsSessionIDs).equals(new HashSet<>(sessionIDs))) {
+      if (!existsSessionIDs.containsAll(sessionIDs)) {
         LOGGER.error("server session_id_list does not equal to active_session_id_list.");
         fail();
       }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/session/NewSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/session/NewSessionIT.java
@@ -395,7 +395,7 @@ public class NewSessionIT {
       List<Long> existsSessionIDs = conn.executeSql("show sessionid;").getSessionIDs();
 
       if (!existsSessionIDs.containsAll(sessionIDs)) {
-        LOGGER.error("server session_id_list does not equal to active_session_id_list.");
+        LOGGER.error("server session_id_list doesn't contain all session IDs.");
         fail();
       }
 


### PR DESCRIPTION
- 更快的 clear data 实现：使用 flushDB 实现 clear data 操作，不逐条删除
- 将默认超时时间从 5s 改为 10s
- 重构异常与日志打印