### PR TITLE
refactor(core): reimplement `StorageEngineClassLoader` to support spi

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageEngineClassLoader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageEngineClassLoader.java
@@ -61,15 +61,19 @@ public class StorageEngineClassLoader extends URLClassLoader {
   @Override
   protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
     synchronized (getClassLoadingLock(name)) {
-      try {
-        Class<?> clazz = findClass(name);
-        if (resolve) {
-          resolveClass(clazz);
-        }
+      Class<?> clazz = findLoadedClass(name);
+      if (clazz != null) {
         return clazz;
+      }
+      try {
+        clazz = findClass(name);
       } catch (ClassNotFoundException e) {
         return super.loadClass(name, resolve);
       }
+      if (resolve) {
+        resolveClass(clazz);
+      }
+      return clazz;
     }
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/storage/StorageManager.java
@@ -157,7 +157,7 @@ public class StorageManager {
       String storage = kAndV[0];
       String driver = kAndV[1];
       try {
-        ClassLoader classLoader = new StorageEngineClassLoader(storage);
+        ClassLoader classLoader = StorageEngineClassLoader.of(storage);
         StorageEngineType type = StorageEngineType.valueOf(storage.toLowerCase());
         classLoaders.put(type, classLoader);
         drivers.put(type, driver);


### PR DESCRIPTION
原来的`StorageEngineClassLoader`没有实现完整的 ClassLoader 功能，不能支持 SPI 机制，因此重新实现。

这个 PR 是是合并 FileSystem 和 Parquet 对接层的 PR 的部分改动，单独抽出来方便 Review。