### PR TITLE
feat(sql): add op "not like"

### DIFF
--- a/.github/workflows/standard-test-suite.yml
+++ b/.github/workflows/standard-test-suite.yml
@@ -1,19 +1,44 @@
 name: Standard Test Suite
 
-#on:
-#    pull_request: # when a PR is opened or reopened
-#        types: [opened, reopened]
-#        branches:
-#            - main
-on: [pull_request]
+on:
+    pull_request: # when a PR is opened or reopened
+        types: [opened, reopened]
+        branches:
+            - main
 
 concurrency:
     group: "${{ github.workflow }}-${{ github.ref }}"
     cancel-in-progress: true
 
 jobs:
+    unit-test:
+        uses: ./.github/workflows/unit-test.yml
+    unit-mds:
+        uses: ./.github/workflows/unit-mds.yml
+    case-regression:
+        uses: ./.github/workflows/case-regression.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    standalone-test:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
     standalone-test-pushdown:
         uses: ./.github/workflows/standalone-test-pushdown.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    db-ce:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    remote-test:
+        uses: ./.github/workflows/remote-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    assemebly-test:
+        uses: ./.github/workflows/assembly-test.yml
+    tpc-h-regression-test:
+        uses: ./.github/workflows/tpc-h.yml
         with:
             os-matrix: '["ubuntu-latest"]'
             metadata-matrix: '["zookeeper"]'

--- a/.github/workflows/standard-test-suite.yml
+++ b/.github/workflows/standard-test-suite.yml
@@ -1,44 +1,19 @@
 name: Standard Test Suite
 
-on:
-    pull_request: # when a PR is opened or reopened
-        types: [opened, reopened]
-        branches:
-            - main
+#on:
+#    pull_request: # when a PR is opened or reopened
+#        types: [opened, reopened]
+#        branches:
+#            - main
+on: [pull_request]
 
 concurrency:
     group: "${{ github.workflow }}-${{ github.ref }}"
     cancel-in-progress: true
 
 jobs:
-    unit-test:
-        uses: ./.github/workflows/unit-test.yml
-    unit-mds:
-        uses: ./.github/workflows/unit-mds.yml
-    case-regression:
-        uses: ./.github/workflows/case-regression.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    standalone-test:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
     standalone-test-pushdown:
         uses: ./.github/workflows/standalone-test-pushdown.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    db-ce:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    remote-test:
-        uses: ./.github/workflows/remote-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    assemebly-test:
-        uses: ./.github/workflows/assembly-test.yml
-    tpc-h-regression-test:
-        uses: ./.github/workflows/tpc-h.yml
         with:
             os-matrix: '["ubuntu-latest"]'
             metadata-matrix: '["zookeeper"]'

--- a/antlr/src/main/antlr4/cn/edu/tsinghua/iginx/sql/Sql.g4
+++ b/antlr/src/main/antlr4/cn/edu/tsinghua/iginx/sql/Sql.g4
@@ -148,7 +148,7 @@ predicate
    : (KEY | path | functionName LR_BRACKET path RR_BRACKET) comparisonOperator constant
    | constant comparisonOperator (KEY | path | functionName LR_BRACKET path RR_BRACKET)
    | path comparisonOperator path
-   | path stringLikeOperator regex = stringLiteral
+   | path OPERATOR_NOT? stringLikeOperator regex = stringLiteral
    | OPERATOR_NOT? LR_BRACKET orExpression RR_BRACKET
    | predicateWithSubquery
    | expression comparisonOperator expression

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/memory/execute/utils/FilterUtils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/physical/memory/execute/utils/FilterUtils.java
@@ -211,6 +211,9 @@ public class FilterUtils {
       case LIKE:
       case LIKE_AND:
         return ValueUtils.regexCompare(valueA, valueB);
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
+        return !ValueUtils.regexCompare(valueA, valueB);
     }
     return false;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/filter/Op.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/filter/Op.java
@@ -262,10 +262,6 @@ public enum Op {
     return op.equals(E) || op.equals(E_AND);
   }
 
-  public static boolean isLikeOp(Op op) {
-    return op.equals(LIKE) || op.equals(LIKE_AND) || op.equals(NOT_LIKE) || op.equals(NOT_LIKE_AND);
-  }
-
   public static boolean isOrOp(Op op) {
     return op.value >= 0 && op.value <= 9;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/filter/Op.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/operator/filter/Op.java
@@ -28,6 +28,7 @@ public enum Op {
   E,
   NE,
   LIKE,
+  NOT_LIKE,
   // and op: [10, 19]
   GE_AND(10),
   G_AND,
@@ -35,7 +36,8 @@ public enum Op {
   L_AND,
   E_AND,
   NE_AND,
-  LIKE_AND;
+  LIKE_AND,
+  NOT_LIKE_AND;
 
   private int value;
 
@@ -79,6 +81,9 @@ public enum Op {
         return GE;
       case LIKE:
       case LIKE_AND:
+        return NOT_LIKE;
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
         return LIKE;
       default:
         return op;
@@ -100,6 +105,8 @@ public enum Op {
       case L:
         return GE_AND;
       case LIKE:
+        return NOT_LIKE_AND;
+      case NOT_LIKE:
         return LIKE_AND;
       case NE_AND:
         return E;
@@ -114,6 +121,8 @@ public enum Op {
       case L_AND:
         return GE;
       case LIKE_AND:
+        return NOT_LIKE;
+      case NOT_LIKE_AND:
         return LIKE;
       default:
         return op;
@@ -170,6 +179,9 @@ public enum Op {
       case "like":
       case "|like":
         return LIKE;
+      case "not like":
+      case "not |like":
+        return NOT_LIKE;
       case "&=":
       case "&==":
         return E_AND;
@@ -186,6 +198,8 @@ public enum Op {
         return LE_AND;
       case "&like":
         return LIKE_AND;
+      case "not &like":
+        return NOT_LIKE_AND;
       default:
         throw new SQLParserException(String.format("Not support comparison operator %s", op));
     }
@@ -207,6 +221,8 @@ public enum Op {
         return "!=";
       case LIKE:
         return "like";
+      case NOT_LIKE:
+        return "not like";
       case GE_AND:
         return "&>=";
       case G_AND:
@@ -221,6 +237,8 @@ public enum Op {
         return "&!=";
       case LIKE_AND:
         return "&like";
+      case NOT_LIKE_AND:
+        return "not &like";
       default:
         return "";
     }
@@ -234,7 +252,7 @@ public enum Op {
    */
   public static String op2StrWithoutAndOr(Op op) {
     String opStr = Op.op2Str(op);
-    if (opStr.startsWith("&")) {
+    if (opStr.contains("&")) {
       return opStr.substring(1);
     }
     return opStr;
@@ -245,7 +263,7 @@ public enum Op {
   }
 
   public static boolean isLikeOp(Op op) {
-    return op.equals(LIKE) || op.equals(LIKE_AND);
+    return op.equals(LIKE) || op.equals(LIKE_AND) || op.equals(NOT_LIKE) || op.equals(NOT_LIKE_AND);
   }
 
   public static boolean isOrOp(Op op) {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/IginXSqlVisitor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/IginXSqlVisitor.java
@@ -1394,7 +1394,11 @@ public class IginXSqlVisitor extends SqlBaseVisitor<Statement> {
 
     Op op;
     if (ctx.stringLikeOperator() != null) {
-      op = Op.str2Op(ctx.stringLikeOperator().getText().trim().toLowerCase());
+      String strOp = ctx.stringLikeOperator().getText().trim().toLowerCase();
+      if (ctx.OPERATOR_NOT() != null) {
+        strOp = "not " + strOp;
+      }
+      op = Op.str2Op(strOp);
     } else {
       op = Op.str2Op(ctx.comparisonOperator().getText().trim().toLowerCase());
       // deal with sub clause like 100 < path

--- a/core/src/test/java/cn/edu/tsinghua/iginx/engine/logical/utils/LogicalFilterUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iginx/engine/logical/utils/LogicalFilterUtilsTest.java
@@ -108,6 +108,18 @@ public class LogicalFilterUtilsTest {
     filter = statement.getFilter();
     System.out.println(filter.toString());
     System.out.println(LogicalFilterUtils.removeNot(filter).toString());
+
+    select = "SELECT a FROM root WHERE !(e like \".*aa.*\");";
+    statement = (UnarySelectStatement) TestUtils.buildStatement(select);
+    filter = statement.getFilter();
+    System.out.println(filter.toString());
+    System.out.println(LogicalFilterUtils.removeNot(filter).toString());
+
+    select = "SELECT a FROM root WHERE !(e not like \".*aa.*\");";
+    statement = (UnarySelectStatement) TestUtils.buildStatement(select);
+    filter = statement.getFilter();
+    System.out.println(filter.toString());
+    System.out.println(LogicalFilterUtils.removeNot(filter).toString());
   }
 
   @Test

--- a/dataSource/filesystem/src/main/java/cn/edu/tsinghua/iginx/filesystem/tools/FilterTransformer.java
+++ b/dataSource/filesystem/src/main/java/cn/edu/tsinghua/iginx/filesystem/tools/FilterTransformer.java
@@ -113,6 +113,8 @@ public class FilterTransformer {
         return FSOp.LE;
       case LIKE:
         return FSOp.LIKE;
+      case NOT_LIKE:
+        return FSOp.NOT_LIKE;
       case NE:
         return FSOp.NE;
       case E:
@@ -127,6 +129,8 @@ public class FilterTransformer {
         return FSOp.LE_AND;
       case LIKE_AND:
         return FSOp.LIKE_AND;
+      case NOT_LIKE_AND:
+        return FSOp.NOT_LIKE_AND;
       case NE_AND:
         return FSOp.NE_AND;
       case E_AND:
@@ -234,6 +238,8 @@ public class FilterTransformer {
         return LE;
       case LIKE:
         return LIKE;
+      case NOT_LIKE:
+        return NOT_LIKE;
       case NE:
         return NE;
       case E:
@@ -248,6 +254,8 @@ public class FilterTransformer {
         return LE_AND;
       case LIKE_AND:
         return LIKE_AND;
+      case NOT_LIKE_AND:
+        return NOT_LIKE_AND;
       case NE_AND:
         return NE_AND;
       case E_AND:

--- a/dataSource/iotdb12/src/main/java/cn/edu/tsinghua/iginx/iotdb/tools/FilterTransformer.java
+++ b/dataSource/iotdb12/src/main/java/cn/edu/tsinghua/iginx/iotdb/tools/FilterTransformer.java
@@ -17,8 +17,6 @@
  */
 package cn.edu.tsinghua.iginx.iotdb.tools;
 
-import static cn.edu.tsinghua.iginx.engine.shared.operator.filter.Op.isLikeOp;
-
 import cn.edu.tsinghua.iginx.engine.shared.operator.filter.*;
 import cn.edu.tsinghua.iginx.thrift.DataType;
 
@@ -80,14 +78,22 @@ public class FilterTransformer {
             ? "'" + filter.getValue().getBinaryVAsString() + "'"
             : filter.getValue().getValue().toString();
 
-    if (isLikeOp(filter.getOp())) {
-      if (!value.endsWith("$'")) {
-        value = value.substring(0, value.length() - 1) + "$'";
-      }
-      return filter.getPath() + " regexp " + value;
+    switch (filter.getOp()) {
+      case LIKE:
+      case LIKE_AND:
+        if (!value.endsWith("$'")) {
+          value = value.substring(0, value.length() - 1) + "$'";
+        }
+        return filter.getPath() + " regexp " + value;
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
+        if (!value.endsWith("$'")) {
+          value = value.substring(0, value.length() - 1) + "$'";
+        }
+        return " not (" + filter.getPath() + " regexp " + value + ")";
+      default:
+        return filter.getPath() + " " + Op.op2StrWithoutAndOr(filter.getOp()) + " " + value;
     }
-
-    return filter.getPath() + " " + Op.op2StrWithoutAndOr(filter.getOp()) + " " + value;
   }
 
   private static String toString(OrFilter filter) {

--- a/dataSource/iotdb12/src/main/java/cn/edu/tsinghua/iginx/iotdb/tools/FilterTransformer.java
+++ b/dataSource/iotdb12/src/main/java/cn/edu/tsinghua/iginx/iotdb/tools/FilterTransformer.java
@@ -87,10 +87,8 @@ public class FilterTransformer {
         return filter.getPath() + " regexp " + value;
       case NOT_LIKE:
       case NOT_LIKE_AND:
-        if (!value.endsWith("$'")) {
-          value = value.substring(0, value.length() - 1) + "$'";
-        }
-        return " not (" + filter.getPath() + " regexp " + value + ")";
+        // iotdb12不支持使用not like
+        return "";
       default:
         return filter.getPath() + " " + Op.op2StrWithoutAndOr(filter.getOp()) + " " + value;
     }

--- a/dataSource/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/tools/FilterUtils.java
+++ b/dataSource/mongodb/src/main/java/cn/edu/tsinghua/iginx/mongodb/tools/FilterUtils.java
@@ -331,6 +331,15 @@ public class FilterUtils {
                 "$regexMatch",
                 new Document("input", "$" + fieldName)
                     .append("regex", value.asString().getValue() + "$")));
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
+        return expr(
+            new Document(
+                "$not",
+                new Document(
+                    "$regexMatch",
+                    new Document("input", "$" + fieldName)
+                        .append("regex", value.asString().getValue() + "$"))));
     }
     throw new IllegalStateException("unexpected Filter op: " + op);
   }

--- a/dataSource/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/manager/data/ProjectUtils.java
+++ b/dataSource/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/manager/data/ProjectUtils.java
@@ -183,6 +183,7 @@ class ProjectUtils {
       case E:
       case NE:
       case LIKE:
+      case NOT_LIKE:
         return false;
       case GE_AND:
       case G_AND:
@@ -191,6 +192,7 @@ class ProjectUtils {
       case E_AND:
       case NE_AND:
       case LIKE_AND:
+      case NOT_LIKE_AND:
         return true;
       default:
         throw new IllegalStateException("unsupported op: " + op);
@@ -220,6 +222,9 @@ class ProjectUtils {
       case LIKE:
       case LIKE_AND:
         return Op.LIKE;
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
+        return Op.NOT_LIKE;
       default:
         throw new IllegalStateException("unsupported op: " + op);
     }

--- a/dataSource/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/server/FilterTransformer.java
+++ b/dataSource/parquet/src/main/java/cn/edu/tsinghua/iginx/parquet/server/FilterTransformer.java
@@ -115,6 +115,8 @@ public class FilterTransformer {
         return RawFilterOp.LE;
       case LIKE:
         return RawFilterOp.LIKE;
+      case NOT_LIKE:
+        return RawFilterOp.NOT_LIKE;
       case NE:
         return RawFilterOp.NE;
       case E:
@@ -129,6 +131,8 @@ public class FilterTransformer {
         return RawFilterOp.LE_AND;
       case LIKE_AND:
         return RawFilterOp.LIKE_AND;
+      case NOT_LIKE_AND:
+        return RawFilterOp.NOT_LIKE_AND;
       case NE_AND:
         return RawFilterOp.NE_AND;
       case E_AND:
@@ -236,6 +240,8 @@ public class FilterTransformer {
         return LE;
       case LIKE:
         return LIKE;
+      case NOT_LIKE:
+        return NOT_LIKE;
       case NE:
         return NE;
       case E:
@@ -250,6 +256,8 @@ public class FilterTransformer {
         return LE_AND;
       case LIKE_AND:
         return LIKE_AND;
+      case NOT_LIKE_AND:
+        return NOT_LIKE_AND;
       case NE_AND:
         return NE_AND;
       case E_AND:

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/AbstractRelationalMeta.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/AbstractRelationalMeta.java
@@ -171,6 +171,13 @@ public abstract class AbstractRelationalMeta {
    */
   public abstract String getRegexpOp();
 
+  /**
+   * 获取不匹配正则表达式的操作符
+   *
+   * @return 不匹配正则表达式的操作符
+   */
+  public abstract String getNotRegexpOp();
+
   /** jdbc获取元数据是否支持反斜杠的识别 */
   public abstract boolean jdbcSupportSpecialChar();
 }

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/JDBCMeta.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/JDBCMeta.java
@@ -59,6 +59,8 @@ public class JDBCMeta extends AbstractRelationalMeta {
 
   private String regexpOp;
 
+  private String notRegexOp;
+
   private boolean jdbcSupportBackslash;
 
   public JDBCMeta(StorageEngineMeta meta, String propertiesPath) throws IOException {
@@ -85,6 +87,7 @@ public class JDBCMeta extends AbstractRelationalMeta {
     upsertConflictStatement = properties.getProperty("upsert_conflict_statement");
     isSupportFullJoin = Boolean.parseBoolean(properties.getProperty("is_support_full_join"));
     regexpOp = properties.getProperty("regex_like_symbol");
+    notRegexOp = properties.getProperty("not_regex_like_symbol");
     jdbcSupportBackslash =
         Boolean.parseBoolean(properties.getProperty("jdbc_support_special_char"));
   }
@@ -152,6 +155,11 @@ public class JDBCMeta extends AbstractRelationalMeta {
   @Override
   public String getRegexpOp() {
     return regexpOp;
+  }
+
+  @Override
+  public String getNotRegexpOp() {
+    return notRegexOp;
   }
 
   @Override

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/PostgreSQLMeta.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/meta/PostgreSQLMeta.java
@@ -120,6 +120,11 @@ public class PostgreSQLMeta extends AbstractRelationalMeta {
   }
 
   @Override
+  public String getNotRegexpOp() {
+    return "!~";
+  }
+
+  @Override
   public boolean jdbcSupportSpecialChar() {
     return true;
   }

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/tools/FilterTransformer.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/tools/FilterTransformer.java
@@ -100,7 +100,7 @@ public class FilterTransformer {
         break;
       case NOT_LIKE:
       case NOT_LIKE_AND:
-        op = "not " + relationalMeta.getRegexpOp();
+        op = relationalMeta.getNotRegexpOp();
         value = "'" + filter.getValue().getBinaryVAsString() + "$" + "'";
         break;
       default:

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/tools/FilterTransformer.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/tools/FilterTransformer.java
@@ -17,7 +17,6 @@
  */
 package cn.edu.tsinghua.iginx.relational.tools;
 
-import static cn.edu.tsinghua.iginx.engine.shared.operator.filter.Op.isLikeOp;
 import static cn.edu.tsinghua.iginx.relational.tools.Constants.*;
 
 import cn.edu.tsinghua.iginx.engine.shared.operator.filter.*;
@@ -90,20 +89,29 @@ public class FilterTransformer {
   private String toString(ValueFilter filter) {
     RelationSchema schema = new RelationSchema(filter.getPath(), relationalMeta.getQuote());
     String path = schema.getQuoteFullName();
+    String op;
+    Object value;
 
-    String op =
-        isLikeOp(filter.getOp())
-            ? relationalMeta.getRegexpOp()
-            : Op.op2StrWithoutAndOr(filter.getOp())
-                .replace("==", "="); // postgresql does not support "==" but uses "=" instead
-
-    String regexSymbol = isLikeOp(filter.getOp()) ? "$" : "";
-
-    Object value =
-        filter.getValue().getDataType() == DataType.BINARY
-            ? "'" + filter.getValue().getBinaryVAsString() + regexSymbol + "'"
-            : filter.getValue().getValue();
-
+    switch (filter.getOp()) {
+      case LIKE:
+      case LIKE_AND:
+        op = relationalMeta.getRegexpOp();
+        value = "'" + filter.getValue().getBinaryVAsString() + "$" + "'";
+        break;
+      case NOT_LIKE:
+      case NOT_LIKE_AND:
+        op = "not " + relationalMeta.getRegexpOp();
+        value = "'" + filter.getValue().getBinaryVAsString() + "$" + "'";
+        break;
+      default:
+        // postgresql does not support "==" but uses "=" instead
+        op = Op.op2StrWithoutAndOr(filter.getOp()).replace("==", "=");
+        value =
+            filter.getValue().getDataType() == DataType.BINARY
+                ? "'" + filter.getValue().getBinaryVAsString() + "'"
+                : filter.getValue().getValue();
+        break;
+    }
     return path + " " + op + " " + value;
   }
 

--- a/dataSource/relational/src/main/resources/mysql-meta-template.properties
+++ b/dataSource/relational/src/main/resources/mysql-meta-template.properties
@@ -40,6 +40,8 @@ database_query_sql=SELECT SCHEMA_NAME AS datname FROM information_schema.schemat
 is_support_full_join=false
 # filter中正则匹配的符号
 regex_like_symbol=REGEXP
+# filter中不匹配正则表达式的符号
+not_regex_like_symbol=NOT REGEXP
 # jdbc元数据获取是否支持特殊字符识别
 jdbc_support_special_char=true
 

--- a/dataSource/relational/src/main/resources/oceanbase-meta.properties
+++ b/dataSource/relational/src/main/resources/oceanbase-meta.properties
@@ -40,6 +40,8 @@ database_query_sql=SELECT SCHEMA_NAME AS datname FROM information_schema.schemat
 is_support_full_join=false
 # filter中正则匹配的符号
 regex_like_symbol=REGEXP
+# filter中不匹配正则表达式的符号
+not_regex_like_symbol=NOT REGEXP
 # jdbc元数据是否支持特殊字符的识别
 jdbc_support_special_char=false
 

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/sql/SQLSessionIT.java
@@ -448,6 +448,21 @@ public class SQLSessionIT {
             + "Total line number = 4\n";
     executor.executeAndCompare(query, expected);
 
+    query = "SELECT c FROM us.d2 WHERE c not like \"^a.*\";";
+    expected =
+        "ResultSets:\n"
+            + "+---+-------+\n"
+            + "|key|us.d2.c|\n"
+            + "+---+-------+\n"
+            + "|  2|  sadaa|\n"
+            + "|  3| sadada|\n"
+            + "|  5| deadsa|\n"
+            + "|  6|  dasda|\n"
+            + "|  8|  frgsa|\n"
+            + "+---+-------+\n"
+            + "Total line number = 5\n";
+    executor.executeAndCompare(query, expected);
+
     query = "SELECT c FROM us.d2 WHERE c like \"^[s|f].*\";";
     expected =
         "ResultSets:\n"
@@ -459,6 +474,22 @@ public class SQLSessionIT {
             + "|  8|  frgsa|\n"
             + "+---+-------+\n"
             + "Total line number = 3\n";
+    executor.executeAndCompare(query, expected);
+
+    query = "SELECT c FROM us.d2 WHERE c not like \"^[s|f].*\";";
+    expected =
+        "ResultSets:\n"
+            + "+---+-------+\n"
+            + "|key|us.d2.c|\n"
+            + "+---+-------+\n"
+            + "|  1|  asdas|\n"
+            + "|  4|  asdad|\n"
+            + "|  5| deadsa|\n"
+            + "|  6|  dasda|\n"
+            + "|  7| asdsad|\n"
+            + "|  9|  asdad|\n"
+            + "+---+-------+\n"
+            + "Total line number = 6\n";
     executor.executeAndCompare(query, expected);
 
     query = "SELECT c FROM us.d2 WHERE c like \"^.*[s|d]\";";
@@ -473,6 +504,21 @@ public class SQLSessionIT {
             + "|  9|  asdad|\n"
             + "+---+-------+\n"
             + "Total line number = 4\n";
+    executor.executeAndCompare(query, expected);
+
+    query = "SELECT c FROM us.d2 WHERE c not like \"^.*[s|d]\";";
+    expected =
+        "ResultSets:\n"
+            + "+---+-------+\n"
+            + "|key|us.d2.c|\n"
+            + "+---+-------+\n"
+            + "|  2|  sadaa|\n"
+            + "|  3| sadada|\n"
+            + "|  5| deadsa|\n"
+            + "|  6|  dasda|\n"
+            + "|  8|  frgsa|\n"
+            + "+---+-------+\n"
+            + "Total line number = 5\n";
     executor.executeAndCompare(query, expected);
 
     StringBuilder builder = new StringBuilder();

--- a/thrift/src/main/proto/filesystem.thrift
+++ b/thrift/src/main/proto/filesystem.thrift
@@ -51,6 +51,7 @@ enum FSOp {
     E,
     NE,
     LIKE,
+    NOT_LIKE,
     GE_AND,
     G_AND,
     LE_AND,
@@ -58,6 +59,7 @@ enum FSOp {
     E_AND,
     NE_AND,
     LIKE_AND,
+    NOT_LIKE_AND,
     UNKNOWN,
 }
 

--- a/thrift/src/main/proto/parquet.thrift
+++ b/thrift/src/main/proto/parquet.thrift
@@ -58,6 +58,7 @@ enum RawFilterOp {
     E,
     NE,
     LIKE,
+    NOT_LIKE,
     GE_AND,
     G_AND,
     LE_AND,
@@ -65,6 +66,7 @@ enum RawFilterOp {
     E_AND,
     NE_AND,
     LIKE_AND,
+    NOT_LIKE_AND,
     UNKNOWN,
 }
 


### PR DESCRIPTION
NotFilterRemoveRule优化器会消除所有filter中的 `not `符号，例如将 `!(a>1)` 改写为 `a<=1`，但是 `like` 没有对应的取反的比较运算符，因此新增实现 `not like`。