### PR TITLE
fix(RelationalStorage): modify HikariCP config

### DIFF
--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
@@ -157,7 +157,7 @@ public class RelationalStorage implements IStorage {
       config.setIdleTimeout(
           Long.parseLong(meta.getExtraParams().getOrDefault("idle_timeout", "10000")));
       config.setMaximumPoolSize(
-          Integer.parseInt(meta.getExtraParams().getOrDefault("maximum_pool_size", "10")));
+          Integer.parseInt(meta.getExtraParams().getOrDefault("maximum_pool_size", "20")));
       config.setMinimumIdle(
           Integer.parseInt(meta.getExtraParams().getOrDefault("minimum_idle", "1")));
       config.addDataSourceProperty(

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
@@ -152,7 +152,7 @@ public class RelationalStorage implements IStorage {
       config.setLeakDetectionThreshold(2500);
       config.setConnectionTimeout(30000);
       config.setIdleTimeout(10000);
-      config.setMaximumPoolSize(10);
+      config.setMaximumPoolSize(20);
       config.setMinimumIdle(1);
       config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
 
@@ -526,7 +526,7 @@ public class RelationalStorage implements IStorage {
 
       List<String> databaseNameList = new ArrayList<>();
       List<ResultSet> resultSets = new ArrayList<>();
-      Statement stmt;
+      Statement stmt = null;
 
       Map<String, String> tableNameToColumnNames =
           splitAndMergeQueryPatterns(databaseName, project.getPatterns());
@@ -650,6 +650,7 @@ public class RelationalStorage implements IStorage {
                   filter,
                   project.getTagFilter(),
                   Collections.singletonList(conn),
+                  Collections.singletonList(stmt),
                   relationalMeta));
       return new TaskExecuteResult(rowStream);
     } catch (SQLException e) {
@@ -1048,6 +1049,7 @@ public class RelationalStorage implements IStorage {
 
   private TaskExecuteResult executeProjectDummyWithFilter(Project project, Filter filter) {
     List<Connection> connList = new ArrayList<>();
+    List<Statement> stmtList = new ArrayList<>();
     try {
       List<String> databaseNameList = new ArrayList<>();
       List<ResultSet> resultSets = new ArrayList<>();
@@ -1105,6 +1107,7 @@ public class RelationalStorage implements IStorage {
               continue;
             }
             databaseNameList.add(databaseName);
+            stmtList.add(stmt);
             resultSets.add(rs);
           }
         }
@@ -1193,6 +1196,7 @@ public class RelationalStorage implements IStorage {
           }
           if (rs != null) {
             databaseNameList.add(databaseName);
+            stmtList.add(stmt);
             resultSets.add(rs);
           }
         }
@@ -1207,6 +1211,7 @@ public class RelationalStorage implements IStorage {
                   filter,
                   project.getTagFilter(),
                   connList,
+                  stmtList,
                   relationalMeta));
       return new TaskExecuteResult(rowStream);
     } catch (SQLException e) {

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
@@ -148,13 +148,13 @@ public class RelationalStorage implements IStorage {
       config.setJdbcUrl(getUrl(databaseName, meta));
       config.setUsername(meta.getExtraParams().get(USERNAME));
       config.setPassword(meta.getExtraParams().get(PASSWORD));
-      config.addDataSourceProperty("prepStmtCacheSize", "250");
-      config.setLeakDetectionThreshold(2500);
-      config.setConnectionTimeout(30000);
-      config.setIdleTimeout(10000);
-      config.setMaximumPoolSize(20);
-      config.setMinimumIdle(1);
-      config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+      config.addDataSourceProperty("prepStmtCacheSize", meta.getExtraParams().getOrDefault("prep_stmt_cache_size", "250"));
+      config.setLeakDetectionThreshold(Long.parseLong(meta.getExtraParams().getOrDefault("leak_detection_threshold", "2500")));
+      config.setConnectionTimeout(Long.parseLong(meta.getExtraParams().getOrDefault("connection_timeout", "30000")));
+      config.setIdleTimeout(Long.parseLong(meta.getExtraParams().getOrDefault("idle_timeout", "10000")));
+      config.setMaximumPoolSize(Integer.parseInt(meta.getExtraParams().getOrDefault("maximum_pool_size", "10")));
+      config.setMinimumIdle(Integer.parseInt(meta.getExtraParams().getOrDefault("minimum_idle", "1")));
+      config.addDataSourceProperty("prepStmtCacheSqlLimit", meta.getExtraParams().getOrDefault("prep_stmt_cache_sql_limit", "2048"));
 
       HikariDataSource newDataSource = new HikariDataSource(config);
       connectionPoolMap.put(databaseName, newDataSource);

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
@@ -148,13 +148,21 @@ public class RelationalStorage implements IStorage {
       config.setJdbcUrl(getUrl(databaseName, meta));
       config.setUsername(meta.getExtraParams().get(USERNAME));
       config.setPassword(meta.getExtraParams().get(PASSWORD));
-      config.addDataSourceProperty("prepStmtCacheSize", meta.getExtraParams().getOrDefault("prep_stmt_cache_size", "250"));
-      config.setLeakDetectionThreshold(Long.parseLong(meta.getExtraParams().getOrDefault("leak_detection_threshold", "2500")));
-      config.setConnectionTimeout(Long.parseLong(meta.getExtraParams().getOrDefault("connection_timeout", "30000")));
-      config.setIdleTimeout(Long.parseLong(meta.getExtraParams().getOrDefault("idle_timeout", "10000")));
-      config.setMaximumPoolSize(Integer.parseInt(meta.getExtraParams().getOrDefault("maximum_pool_size", "10")));
-      config.setMinimumIdle(Integer.parseInt(meta.getExtraParams().getOrDefault("minimum_idle", "1")));
-      config.addDataSourceProperty("prepStmtCacheSqlLimit", meta.getExtraParams().getOrDefault("prep_stmt_cache_sql_limit", "2048"));
+      config.addDataSourceProperty(
+          "prepStmtCacheSize", meta.getExtraParams().getOrDefault("prep_stmt_cache_size", "250"));
+      config.setLeakDetectionThreshold(
+          Long.parseLong(meta.getExtraParams().getOrDefault("leak_detection_threshold", "2500")));
+      config.setConnectionTimeout(
+          Long.parseLong(meta.getExtraParams().getOrDefault("connection_timeout", "30000")));
+      config.setIdleTimeout(
+          Long.parseLong(meta.getExtraParams().getOrDefault("idle_timeout", "10000")));
+      config.setMaximumPoolSize(
+          Integer.parseInt(meta.getExtraParams().getOrDefault("maximum_pool_size", "10")));
+      config.setMinimumIdle(
+          Integer.parseInt(meta.getExtraParams().getOrDefault("minimum_idle", "1")));
+      config.addDataSourceProperty(
+          "prepStmtCacheSqlLimit",
+          meta.getExtraParams().getOrDefault("prep_stmt_cache_sql_limit", "2048"));
 
       HikariDataSource newDataSource = new HikariDataSource(config);
       connectionPoolMap.put(databaseName, newDataSource);

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/RelationalStorage.java
@@ -534,7 +534,7 @@ public class RelationalStorage implements IStorage {
 
       List<String> databaseNameList = new ArrayList<>();
       List<ResultSet> resultSets = new ArrayList<>();
-      Statement stmt = null;
+      Statement stmt;
 
       Map<String, String> tableNameToColumnNames =
           splitAndMergeQueryPatterns(databaseName, project.getPatterns());
@@ -658,7 +658,6 @@ public class RelationalStorage implements IStorage {
                   filter,
                   project.getTagFilter(),
                   Collections.singletonList(conn),
-                  Collections.singletonList(stmt),
                   relationalMeta));
       return new TaskExecuteResult(rowStream);
     } catch (SQLException e) {
@@ -1057,7 +1056,6 @@ public class RelationalStorage implements IStorage {
 
   private TaskExecuteResult executeProjectDummyWithFilter(Project project, Filter filter) {
     List<Connection> connList = new ArrayList<>();
-    List<Statement> stmtList = new ArrayList<>();
     try {
       List<String> databaseNameList = new ArrayList<>();
       List<ResultSet> resultSets = new ArrayList<>();
@@ -1115,7 +1113,6 @@ public class RelationalStorage implements IStorage {
               continue;
             }
             databaseNameList.add(databaseName);
-            stmtList.add(stmt);
             resultSets.add(rs);
           }
         }
@@ -1204,7 +1201,6 @@ public class RelationalStorage implements IStorage {
           }
           if (rs != null) {
             databaseNameList.add(databaseName);
-            stmtList.add(stmt);
             resultSets.add(rs);
           }
         }
@@ -1219,7 +1215,6 @@ public class RelationalStorage implements IStorage {
                   filter,
                   project.getTagFilter(),
                   connList,
-                  stmtList,
                   relationalMeta));
       return new TaskExecuteResult(rowStream);
     } catch (SQLException e) {

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/query/entity/RelationQueryRowStream.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/query/entity/RelationQueryRowStream.java
@@ -41,7 +41,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,8 +75,6 @@ public class RelationQueryRowStream implements RowStream {
 
   private List<Connection> connList;
 
-  private List<Statement> stmtList;
-
   private AbstractRelationalMeta relationalMeta;
 
   private String fullKeyName = KEY_NAME;
@@ -91,14 +88,12 @@ public class RelationQueryRowStream implements RowStream {
       Filter filter,
       TagFilter tagFilter,
       List<Connection> connList,
-      List<Statement> stmtList,
       AbstractRelationalMeta relationalMeta)
       throws SQLException {
     this.resultSets = resultSets;
     this.isDummy = isDummy;
     this.filter = filter;
     this.connList = connList;
-    this.stmtList = stmtList;
     this.relationalMeta = relationalMeta;
 
     if (resultSets.isEmpty()) {
@@ -200,14 +195,11 @@ public class RelationQueryRowStream implements RowStream {
       for (ResultSet resultSet : resultSets) {
         resultSet.close();
       }
-      for (Statement stmt : stmtList) {
-        stmt.close();
-      }
       for (Connection conn : connList) {
         conn.close();
       }
     } catch (SQLException e) {
-      LOGGER.error("error occurred when closing resultSets, statements or connections", e);
+      LOGGER.error("error occurred when closing resultSets or connections", e);
     }
   }
 

--- a/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/query/entity/RelationQueryRowStream.java
+++ b/dataSource/relational/src/main/java/cn/edu/tsinghua/iginx/relational/query/entity/RelationQueryRowStream.java
@@ -41,6 +41,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,8 @@ public class RelationQueryRowStream implements RowStream {
 
   private List<Connection> connList;
 
+  private List<Statement> stmtList;
+
   private AbstractRelationalMeta relationalMeta;
 
   private String fullKeyName = KEY_NAME;
@@ -88,12 +91,14 @@ public class RelationQueryRowStream implements RowStream {
       Filter filter,
       TagFilter tagFilter,
       List<Connection> connList,
+      List<Statement> stmtList,
       AbstractRelationalMeta relationalMeta)
       throws SQLException {
     this.resultSets = resultSets;
     this.isDummy = isDummy;
     this.filter = filter;
     this.connList = connList;
+    this.stmtList = stmtList;
     this.relationalMeta = relationalMeta;
 
     if (resultSets.isEmpty()) {
@@ -195,11 +200,14 @@ public class RelationQueryRowStream implements RowStream {
       for (ResultSet resultSet : resultSets) {
         resultSet.close();
       }
+      for (Statement stmt : stmtList) {
+        stmt.close();
+      }
       for (Connection conn : connList) {
         conn.close();
       }
     } catch (SQLException e) {
-      LOGGER.error("error occurred when closing resultSets or connections", e);
+      LOGGER.error("error occurred when closing resultSets, statements or connections", e);
     }
   }
 

--- a/docs/quickStarts/IGinXManual-EnglishVersion.md
+++ b/docs/quickStarts/IGinXManual-EnglishVersion.md
@@ -321,6 +321,18 @@ In order to facilitate installation and management of IGinX, IGinX provides user
 | statisticsCollectorClassName | Statistics collection class                                                 | cn.edu.tsinghua.iginx.statistics.StatisticsCollector                                                                                                                                                                                                                                                                                  |
 | statisticsLogInterval        | Statistics print interval, in milliseconds                                  | 1000                                                                                                                                                                                                                                                                                                                                  |
 
+When connecting to relational databases such as PostgreSQL and MySQL, you can configure the parameters of the HikariDataSource at `storageEngineList`
+
+|    Configuration Item     |                           Description                           | Defalt |
+|---------------------------|-----------------------------------------------------------------|--------|
+| connection_timeout        | Connection timeout (ms)                                         | 30000  |
+| idle_timeout              | Idle connection timeout (ms)                                    | 10000  |
+| maximum_pool_size         | The maximum number of connections in the connection pool        | 20     |
+| minimum_idle              | Minimum number of idle connections in the connection pool       | 1      |
+| leak_detection_threshold  | Threshold for detecting connection leaks (ms)                   | 2500   |
+| prep_stmt_cache_size      | Number of SQL precompiled objects cached                        | 250    |
+| prep_stmt_cache_sql_limit | The upper limit of the number of SQL precompiled objects cached | 2048   |
+
 #### Rest Configuration
 
 | Configuration item |          Description           | Default value |

--- a/docs/quickStarts/IGinXManual.md
+++ b/docs/quickStarts/IGinXManual.md
@@ -320,6 +320,18 @@ IGinX、Rest、元数据管理三方面配置。
 | statisticsCollectorClassName | 统计信息收集类              | cn.edu.tsinghua.iginx.statistics.StatisticsCollector                                                                                                                                                                                                                                                                                  |
 | statisticsLogInterval        | 统计信息打印间隔，单位毫秒        | 1000                                                                                                                                                                                                                                                                                                                                  |
 
+连接PostgreSQL、MySQL等关系数据库时，可在storageEngineList处配置HikariDataSource连接池的参数
+
+|            配置项            |        描述        |  默认值  |
+|---------------------------|------------------|-------|
+| connection_timeout        | 连接超时时间（单位：毫秒）    | 30000 |
+| idle_timeout              | 空闲连接超时时间（单位：毫秒）  | 10000 |
+| maximum_pool_size         | 连接池中的最大连接数       | 20    |
+| minimum_idle              | 连接池中的最小空闲连接数     | 1     |
+| leak_detection_threshold  | 检测连接泄漏的阈值（单位：毫秒） | 2500  |
+| prep_stmt_cache_size      | SQL预编译对象缓存个数     | 250   |
+| prep_stmt_cache_sql_limit | SQL预编译对象缓存个数上限   | 2048  |
+
 #### Rest 配置
 
 |        配置项        |      描述      |   默认值   |


### PR DESCRIPTION
- 增加RelationalStorage中HikariCP的最大连接数至20
- 将RelationalStorage中的HikariDataSource连接池的配置设置为可选参数，可在add storageengine时配置
  - connection_timeout：连接超时时间，默认为30000，单位毫秒
  - idle_timeout：空闲连接超时时间，默认为10000，单位毫秒
  - maximum_pool_size：连接池中的最大连接数，默认为20
  - minimum_idle：连接池中的最小空闲连接数，默认为1
  - leak_detection_threshold：检测连接泄漏的阈值，默认为2500，单位毫秒
  - prep_stmt_cache_size：SQL预编译对象缓存个数，默认为250
  - prep_stmt_cache_sql_limit：SQL预编译对象缓存个数上限，默认为2048 