### PR TITLE
fix(UDF): remove UDFs completely

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/IginxWorker.java
@@ -1072,6 +1072,7 @@ public class IginxWorker implements IService.Iface {
         FileUtils.deleteFileOrDir(file);
       }
       metaManager.dropTransformTask(name);
+      FunctionManager.getInstance().removeFunction(name);
       LOGGER.info("Register file has been dropped, path={}", filePath);
       return RpcUtils.SUCCESS;
     } catch (IOException e) {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/manager/FunctionManager.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/manager/FunctionManager.java
@@ -35,6 +35,7 @@ import cn.edu.tsinghua.iginx.engine.shared.function.system.Min;
 import cn.edu.tsinghua.iginx.engine.shared.function.system.Ratio;
 import cn.edu.tsinghua.iginx.engine.shared.function.system.Sum;
 import cn.edu.tsinghua.iginx.engine.shared.function.udf.python.PyUDAF;
+import cn.edu.tsinghua.iginx.engine.shared.function.udf.python.PyUDF;
 import cn.edu.tsinghua.iginx.engine.shared.function.udf.python.PyUDSF;
 import cn.edu.tsinghua.iginx.engine.shared.function.udf.python.PyUDTF;
 import cn.edu.tsinghua.iginx.metadata.DefaultMetaManager;
@@ -172,6 +173,10 @@ public class FunctionManager {
   }
 
   public void removeFunction(String identifier) {
+    if (functions.containsKey(identifier)) {
+      PyUDF function = (PyUDF) functions.get(identifier);
+      function.close();
+    }
     functions.remove(identifier);
   }
 
@@ -213,15 +218,15 @@ public class FunctionManager {
     }
 
     if (taskMeta.getType().equals(UDFType.UDAF)) {
-      PyUDAF udaf = new PyUDAF(queue, identifier);
+      PyUDAF udaf = new PyUDAF(queue, identifier, moduleName);
       functions.put(identifier, udaf);
       return udaf;
     } else if (taskMeta.getType().equals(UDFType.UDTF)) {
-      PyUDTF udtf = new PyUDTF(queue, identifier);
+      PyUDTF udtf = new PyUDTF(queue, identifier, moduleName);
       functions.put(identifier, udtf);
       return udtf;
     } else if (taskMeta.getType().equals(UDFType.UDSF)) {
-      PyUDSF udsf = new PyUDSF(queue, identifier);
+      PyUDSF udsf = new PyUDSF(queue, identifier, moduleName);
       functions.put(identifier, udsf);
       return udsf;
     } else {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDAF.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDAF.java
@@ -36,16 +36,14 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import pemja.core.PythonInterpreter;
 
-public class PyUDAF implements UDAF {
+public class PyUDAF extends PyUDF implements UDAF {
 
   private static final String PY_UDAF = "py_udaf";
 
-  private final BlockingQueue<PythonInterpreter> interpreters;
-
   private final String funcName;
 
-  public PyUDAF(BlockingQueue<PythonInterpreter> interpreter, String funcName) {
-    this.interpreters = interpreter;
+  public PyUDAF(BlockingQueue<PythonInterpreter> interpreters, String funcName, String moduleName) {
+    super(interpreters, moduleName);
     this.funcName = funcName;
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDF.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDF.java
@@ -1,3 +1,20 @@
+/*
+ * IGinX - the polystore system with high performance
+ * Copyright (C) Tsinghua University
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package cn.edu.tsinghua.iginx.engine.shared.function.udf.python;
 
 import cn.edu.tsinghua.iginx.engine.shared.function.Function;

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDF.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDF.java
@@ -1,0 +1,28 @@
+package cn.edu.tsinghua.iginx.engine.shared.function.udf.python;
+
+import cn.edu.tsinghua.iginx.engine.shared.function.Function;
+import java.util.concurrent.BlockingQueue;
+import pemja.core.PythonInterpreter;
+
+public abstract class PyUDF implements Function {
+
+  protected final BlockingQueue<PythonInterpreter> interpreters;
+
+  protected final String moduleName;
+
+  public PyUDF(BlockingQueue<PythonInterpreter> interpreters, String moduleName) {
+    this.interpreters = interpreters;
+    this.moduleName = moduleName;
+  }
+
+  public void close() {
+    while (!interpreters.isEmpty()) {
+      PythonInterpreter interpreter = interpreters.poll();
+      if (interpreter != null) {
+        // remove the module
+        interpreter.exec(String.format("import sys; sys.modules.pop('%s', None)", moduleName));
+        interpreter.close();
+      }
+    }
+  }
+}

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDSF.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDSF.java
@@ -35,16 +35,14 @@ import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import pemja.core.PythonInterpreter;
 
-public class PyUDSF implements UDSF {
+public class PyUDSF extends PyUDF implements UDSF {
 
   private static final String PY_UDSF = "py_udsf";
 
-  private final BlockingQueue<PythonInterpreter> interpreters;
-
   private final String funcName;
 
-  public PyUDSF(BlockingQueue<PythonInterpreter> interpreters, String funcName) {
-    this.interpreters = interpreters;
+  public PyUDSF(BlockingQueue<PythonInterpreter> interpreters, String funcName, String moduleName) {
+    super(interpreters, moduleName);
     this.funcName = funcName;
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDTF.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/shared/function/udf/python/PyUDTF.java
@@ -35,16 +35,14 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import pemja.core.PythonInterpreter;
 
-public class PyUDTF implements UDTF {
+public class PyUDTF extends PyUDF implements UDTF {
 
   private static final String PY_UDTF = "py_udtf";
 
-  private final BlockingQueue<PythonInterpreter> interpreters;
-
   private final String funcName;
 
-  public PyUDTF(BlockingQueue<PythonInterpreter> interpreters, String funcName) {
-    this.interpreters = interpreters;
+  public PyUDTF(BlockingQueue<PythonInterpreter> interpreters, String funcName, String moduleName) {
+    super(interpreters, moduleName);
     this.funcName = funcName;
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DropTaskStatement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DropTaskStatement.java
@@ -22,10 +22,8 @@ import cn.edu.tsinghua.iginx.IginxWorker;
 import cn.edu.tsinghua.iginx.engine.shared.RequestContext;
 import cn.edu.tsinghua.iginx.engine.shared.Result;
 import cn.edu.tsinghua.iginx.engine.shared.exception.StatementExecutionException;
-import cn.edu.tsinghua.iginx.engine.shared.function.manager.FunctionManager;
 import cn.edu.tsinghua.iginx.thrift.DropTaskReq;
 import cn.edu.tsinghua.iginx.thrift.Status;
-import cn.edu.tsinghua.iginx.utils.RpcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +36,6 @@ public class DropTaskStatement extends SystemStatement {
 
   private final IginxWorker worker = IginxWorker.getInstance();
 
-  private static final FunctionManager functionManager = FunctionManager.getInstance();
-
   public DropTaskStatement(String name) {
     this.statementType = StatementType.DROP_TASK;
     this.name = name;
@@ -49,9 +45,6 @@ public class DropTaskStatement extends SystemStatement {
   public void execute(RequestContext ctx) throws StatementExecutionException {
     DropTaskReq req = new DropTaskReq(ctx.getSessionId(), name);
     Status status = worker.dropTask(req);
-    if (status.code == RpcUtils.SUCCESS.code) {
-      functionManager.removeFunction(name.trim());
-    }
     ctx.setResult(new Result(status));
   }
 }


### PR DESCRIPTION
# What's wrong:
On deleting UDFs, IGinX would remove the registration script file, remove the python interpreters from function map and done.
But all pemja interpreters would share the modules imported, making the old UDF module still valid.

# Solution:
On deleting UDFs, IGinX would remove the relevant module.