### PR TITLE
fix(optimize): fix column pruning rule for UDF

### DIFF
--- a/optimizer/src/main/java/cn/edu/tsinghua/iginx/logical/optimizer/rules/ColumnPruningRule.java
+++ b/optimizer/src/main/java/cn/edu/tsinghua/iginx/logical/optimizer/rules/ColumnPruningRule.java
@@ -434,6 +434,7 @@ public class ColumnPruningRule extends Rule {
             newColumns.add(column);
           }
         }
+        columns.remove(functionCall.getFunctionStr());
         columns.addAll(newColumns);
       } else {
         List<String> columnNames = functionCall.getParams().getPaths();

--- a/optimizer/src/main/java/cn/edu/tsinghua/iginx/logical/optimizer/rules/ColumnPruningRule.java
+++ b/optimizer/src/main/java/cn/edu/tsinghua/iginx/logical/optimizer/rules/ColumnPruningRule.java
@@ -434,7 +434,6 @@ public class ColumnPruningRule extends Rule {
             newColumns.add(column);
           }
         }
-        columns.clear();
         columns.addAll(newColumns);
       } else {
         List<String> columnNames = functionCall.getParams().getPaths();

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/UDFIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/UDFIT.java
@@ -1408,4 +1408,23 @@ public class UDFIT {
       }
     }
   }
+
+  @Test
+  public void testUDFColumnPruning() {
+    String statement = "SELECT cos(s1), cos(s2) FROM us.d1 LIMIT 5;";
+    String expected =
+        "ResultSets:\n"
+            + "+---+-------------------+-------------------+\n"
+            + "|key|      cos(us.d1.s1)|      cos(us.d1.s2)|\n"
+            + "+---+-------------------+-------------------+\n"
+            + "|  0|                1.0| 0.5403023058681398|\n"
+            + "|  1| 0.5403023058681398|-0.4161468365471424|\n"
+            + "|  2|-0.4161468365471424|-0.9899924966004454|\n"
+            + "|  3|-0.9899924966004454|-0.6536436208636119|\n"
+            + "|  4|-0.6536436208636119|0.28366218546322625|\n"
+            + "+---+-------------------+-------------------+\n"
+            + "Total line number = 5\n";
+
+    assertEquals(expected, tool.execute(statement).getResultInString(false, ""));
+  }
 }


### PR DESCRIPTION
修复列裁剪规则在处理udf时会丢失列的问题，并加入了一个针对udf的测试。