### PR TITLE
fix(delete): fix clear data when no writable engine exists

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
@@ -756,7 +756,7 @@ public class StatementExecutor {
         DeleteStatement deleteStatement = (DeleteStatement) statement;
         if (deleteStatement.isInvolveDummyData()) {
           throw new StatementExecutionException(CLEAR_DUMMY_DATA_CAUTION);
-        } else if (deleteStatement.isNoWritable()) {
+        } else if (deleteStatement.isNoWritableFragment()) {
           throw new StatementExecutionException(NO_WRITABLE_CAUTION);
         } else {
           ctx.setResult(new Result(RpcUtils.SUCCESS));

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
@@ -21,6 +21,7 @@ package cn.edu.tsinghua.iginx.engine;
 
 import static cn.edu.tsinghua.iginx.constant.GlobalConstant.CLEAR_DUMMY_DATA_CAUTION;
 import static cn.edu.tsinghua.iginx.constant.GlobalConstant.KEY_NAME;
+import static cn.edu.tsinghua.iginx.constant.GlobalConstant.NO_WRITABLE_CAUTION;
 import static cn.edu.tsinghua.iginx.engine.shared.function.system.utils.ValueUtils.moveForwardNotNull;
 import static cn.edu.tsinghua.iginx.utils.StringUtils.replaceSpecialCharsWithUnderscore;
 import static cn.edu.tsinghua.iginx.utils.StringUtils.tryParse2Key;
@@ -755,6 +756,8 @@ public class StatementExecutor {
         DeleteStatement deleteStatement = (DeleteStatement) statement;
         if (deleteStatement.isInvolveDummyData()) {
           throw new StatementExecutionException(CLEAR_DUMMY_DATA_CAUTION);
+        } else if (deleteStatement.isNoWritable()) {
+          throw new StatementExecutionException(NO_WRITABLE_CAUTION);
         } else {
           ctx.setResult(new Result(RpcUtils.SUCCESS));
         }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/StatementExecutor.java
@@ -21,7 +21,7 @@ package cn.edu.tsinghua.iginx.engine;
 
 import static cn.edu.tsinghua.iginx.constant.GlobalConstant.CLEAR_DUMMY_DATA_CAUTION;
 import static cn.edu.tsinghua.iginx.constant.GlobalConstant.KEY_NAME;
-import static cn.edu.tsinghua.iginx.constant.GlobalConstant.NO_WRITABLE_CAUTION;
+import static cn.edu.tsinghua.iginx.constant.GlobalConstant.NO_WRITABLE_FRAGMENT_CAUTION;
 import static cn.edu.tsinghua.iginx.engine.shared.function.system.utils.ValueUtils.moveForwardNotNull;
 import static cn.edu.tsinghua.iginx.utils.StringUtils.replaceSpecialCharsWithUnderscore;
 import static cn.edu.tsinghua.iginx.utils.StringUtils.tryParse2Key;
@@ -756,8 +756,8 @@ public class StatementExecutor {
         DeleteStatement deleteStatement = (DeleteStatement) statement;
         if (deleteStatement.isInvolveDummyData()) {
           throw new StatementExecutionException(CLEAR_DUMMY_DATA_CAUTION);
-        } else if (deleteStatement.isNoWritableFragment()) {
-          throw new StatementExecutionException(NO_WRITABLE_CAUTION);
+        } else if (deleteStatement.hasNoWritableFragment()) {
+          throw new StatementExecutionException(NO_WRITABLE_FRAGMENT_CAUTION);
         } else {
           ctx.setResult(new Result(RpcUtils.SUCCESS));
         }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
@@ -84,6 +84,7 @@ public class DeleteGenerator extends AbstractGenerator {
             fragmentsAndStorageUnits.v, fragmentsAndStorageUnits.k);
       } else {
         // no corresponding fragment and no writable engines, no need to execute delete
+        deleteStatement.setNoWritable(true);
         return null;
       }
       fragments = metaManager.getFragmentMapByColumnsInterval(columnsInterval);

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
@@ -82,6 +82,9 @@ public class DeleteGenerator extends AbstractGenerator {
             policy.generateInitialFragmentsAndStorageUnits(deleteStatement);
         metaManager.createInitialFragmentsAndStorageUnits(
             fragmentsAndStorageUnits.v, fragmentsAndStorageUnits.k);
+      } else {
+        // no corresponding fragment and no writable engines, no need to execute delete
+        return null;
       }
       fragments = metaManager.getFragmentMapByColumnsInterval(columnsInterval);
     }

--- a/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/engine/logical/generator/DeleteGenerator.java
@@ -84,7 +84,7 @@ public class DeleteGenerator extends AbstractGenerator {
             fragmentsAndStorageUnits.v, fragmentsAndStorageUnits.k);
       } else {
         // no corresponding fragment and no writable engines, no need to execute delete
-        deleteStatement.setNoWritable(true);
+        deleteStatement.setNoWritableFragment(true);
         return null;
       }
       fragments = metaManager.getFragmentMapByColumnsInterval(columnsInterval);

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
@@ -36,6 +36,7 @@ public class DeleteStatement extends DataStatement {
   private TagFilter tagFilter;
 
   private boolean involveDummyData;
+  private boolean noWritable; // no writable engine, deletion will not be executed.
 
   public DeleteStatement() {
     this.statementType = StatementType.DELETE;
@@ -44,6 +45,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = false;
     this.tagFilter = null;
     this.involveDummyData = false;
+    this.noWritable = false;
   }
 
   public DeleteStatement(List<String> paths, long startKey, long endKey) {
@@ -54,6 +56,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = false;
     this.tagFilter = null;
     this.involveDummyData = false;
+    this.noWritable = false;
   }
 
   public DeleteStatement(List<String> paths) {
@@ -67,6 +70,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = true;
     this.tagFilter = tagFilter;
     this.involveDummyData = false;
+    this.noWritable = false;
   }
 
   public List<String> getPaths() {
@@ -99,6 +103,14 @@ public class DeleteStatement extends DataStatement {
 
   public void setInvolveDummyData(boolean involveDummyData) {
     this.involveDummyData = involveDummyData;
+  }
+
+  public boolean isNoWritable() {
+    return noWritable;
+  }
+
+  public void setNoWritable(boolean noWritable) {
+    this.noWritable = noWritable;
   }
 
   public void setKeyRangesByFilter(Filter filter) {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
@@ -36,7 +36,7 @@ public class DeleteStatement extends DataStatement {
   private TagFilter tagFilter;
 
   private boolean involveDummyData;
-  private boolean noWritable; // no writable engine, deletion will not be executed.
+  private boolean noWritableFragment; // no writable engine, deletion will not be executed.
 
   public DeleteStatement() {
     this.statementType = StatementType.DELETE;
@@ -45,7 +45,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = false;
     this.tagFilter = null;
     this.involveDummyData = false;
-    this.noWritable = false;
+    this.noWritableFragment = false;
   }
 
   public DeleteStatement(List<String> paths, long startKey, long endKey) {
@@ -56,7 +56,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = false;
     this.tagFilter = null;
     this.involveDummyData = false;
-    this.noWritable = false;
+    this.noWritableFragment = false;
   }
 
   public DeleteStatement(List<String> paths) {
@@ -70,7 +70,7 @@ public class DeleteStatement extends DataStatement {
     this.deleteAll = true;
     this.tagFilter = tagFilter;
     this.involveDummyData = false;
-    this.noWritable = false;
+    this.noWritableFragment = false;
   }
 
   public List<String> getPaths() {
@@ -105,12 +105,12 @@ public class DeleteStatement extends DataStatement {
     this.involveDummyData = involveDummyData;
   }
 
-  public boolean isNoWritable() {
-    return noWritable;
+  public boolean isNoWritableFragment() {
+    return noWritableFragment;
   }
 
-  public void setNoWritable(boolean noWritable) {
-    this.noWritable = noWritable;
+  public void setNoWritableFragment(boolean noWritableFragment) {
+    this.noWritableFragment = noWritableFragment;
   }
 
   public void setKeyRangesByFilter(Filter filter) {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/statement/DeleteStatement.java
@@ -105,7 +105,7 @@ public class DeleteStatement extends DataStatement {
     this.involveDummyData = involveDummyData;
   }
 
-  public boolean isNoWritableFragment() {
+  public boolean hasNoWritableFragment() {
     return noWritableFragment;
   }
 

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
@@ -28,6 +28,9 @@ public class GlobalConstant {
   public static final String CLEAR_DUMMY_DATA_CAUTION =
       "Unable to delete data from read-only nodes. The data of the writable nodes has been cleared.";
 
+  public static final String NO_WRITABLE_CAUTION =
+      "There is no writable engine, no need to clear data.";
+
   public static final Long KEY_MIN_VAL = Long.MIN_VALUE + 1;
 
   public static final Long KEY_MAX_VAL = Long.MAX_VALUE;

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
@@ -28,7 +28,7 @@ public class GlobalConstant {
   public static final String CLEAR_DUMMY_DATA_CAUTION =
       "Unable to delete data from read-only nodes. The data of the writable nodes has been cleared.";
 
-  public static final String NO_WRITABLE_CAUTION =
+  public static final String NO_WRITABLE_FRAGMENT_CAUTION =
       "There is no writable fragment, no need to clear data.";
 
   public static final Long KEY_MIN_VAL = Long.MIN_VALUE + 1;

--- a/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
+++ b/shared/src/main/java/cn/edu/tsinghua/iginx/constant/GlobalConstant.java
@@ -29,7 +29,7 @@ public class GlobalConstant {
       "Unable to delete data from read-only nodes. The data of the writable nodes has been cleared.";
 
   public static final String NO_WRITABLE_CAUTION =
-      "There is no writable engine, no need to clear data.";
+      "There is no writable fragment, no need to clear data.";
 
   public static final Long KEY_MIN_VAL = Long.MIN_VALUE + 1;
 


### PR DESCRIPTION
## 解决以下问题：
当系统中只存在只读引擎而不存在可写引擎，`clear data` 会因为找不到可操作的数据源而报错。

## 方案
上述情况中，执行`delete`操作时如果发现系统中无可写引擎，则不执行删除操作，但给用户反馈警告信息。