### PR TITLE
fix(influxdb): high concurrency queries causing iginx to freeze

### DIFF
--- a/dataSource/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBStorage.java
+++ b/dataSource/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBStorage.java
@@ -25,6 +25,7 @@ import static com.influxdb.client.domain.WritePrecision.NS;
 import cn.edu.tsinghua.iginx.engine.logical.utils.LogicalFilterUtils;
 import cn.edu.tsinghua.iginx.engine.physical.exception.PhysicalException;
 import cn.edu.tsinghua.iginx.engine.physical.exception.StorageInitializationException;
+import cn.edu.tsinghua.iginx.engine.physical.memory.execute.Table;
 import cn.edu.tsinghua.iginx.engine.physical.memory.execute.utils.FilterUtils;
 import cn.edu.tsinghua.iginx.engine.physical.storage.IStorage;
 import cn.edu.tsinghua.iginx.engine.physical.storage.domain.Column;
@@ -32,6 +33,8 @@ import cn.edu.tsinghua.iginx.engine.physical.storage.domain.DataArea;
 import cn.edu.tsinghua.iginx.engine.physical.storage.utils.TagKVUtils;
 import cn.edu.tsinghua.iginx.engine.physical.task.TaskExecuteResult;
 import cn.edu.tsinghua.iginx.engine.shared.KeyRange;
+import cn.edu.tsinghua.iginx.engine.shared.data.read.Header;
+import cn.edu.tsinghua.iginx.engine.shared.data.read.Row;
 import cn.edu.tsinghua.iginx.engine.shared.data.write.BitmapView;
 import cn.edu.tsinghua.iginx.engine.shared.data.write.ColumnDataView;
 import cn.edu.tsinghua.iginx.engine.shared.data.write.DataView;
@@ -431,8 +434,7 @@ public class InfluxDBStorage implements IStorage {
             false);
 
     List<FluxTable> tables = client.getQueryApi().query(statement, organization.getId());
-    InfluxDBQueryRowStream rowStream = new InfluxDBQueryRowStream(tables, project, filter);
-    return new TaskExecuteResult(rowStream);
+    return buildQueryResult(tables, project, filter, new ArrayList<>());
   }
 
   @Override
@@ -464,9 +466,7 @@ public class InfluxDBStorage implements IStorage {
       }
     }
 
-    InfluxDBQueryRowStream rowStream =
-        new InfluxDBQueryRowStream(tables, project, filter, BucketNames);
-    return new TaskExecuteResult(rowStream);
+    return buildQueryResult(tables, project, filter, BucketNames);
   }
 
   @Override
@@ -514,8 +514,7 @@ public class InfluxDBStorage implements IStorage {
             false);
 
     List<FluxTable> tables = client.getQueryApi().query(statement, organization.getId());
-    InfluxDBQueryRowStream rowStream = new InfluxDBQueryRowStream(tables, project, null);
-    return new TaskExecuteResult(rowStream);
+    return buildQueryResult(tables, project, null, new ArrayList<>());
   }
 
   @Override
@@ -545,9 +544,7 @@ public class InfluxDBStorage implements IStorage {
       }
     }
 
-    InfluxDBQueryRowStream rowStream =
-        new InfluxDBQueryRowStream(tables, project, null, BucketNames);
-    return new TaskExecuteResult(rowStream);
+    return buildQueryResult(tables, project, null, BucketNames);
   }
 
   private void getBucketQueriesForExecuteDummy(
@@ -1201,6 +1198,23 @@ public class InfluxDBStorage implements IStorage {
     }
 
     return measurementToFieldsMap;
+  }
+
+  // 将 FluxTable 立即转为 IGinX Table，避免在内存中长期持有 FluxTable 导致的 OOM
+  private TaskExecuteResult buildQueryResult(
+      List<FluxTable> tables, Project project, Filter filter, List<String> bucketNames) {
+    try (InfluxDBQueryRowStream rowStream =
+        new InfluxDBQueryRowStream(tables, project, filter, bucketNames)) {
+      Header header = rowStream.getHeader();
+      List<Row> rowList = new ArrayList<>();
+      while (rowStream.hasNext()) {
+        rowList.add(rowStream.next());
+      }
+      Table table = new Table(header, rowList);
+      return new TaskExecuteResult(table);
+    } catch (PhysicalException e) {
+      return new TaskExecuteResult(e);
+    }
   }
 
   @Override

--- a/dataSource/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBStorage.java
+++ b/dataSource/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBStorage.java
@@ -1201,6 +1201,8 @@ public class InfluxDBStorage implements IStorage {
   }
 
   // 将 FluxTable 立即转为 IGinX Table，避免在内存中长期持有 FluxTable 导致的 OOM
+  // 由于 FluxTable 包含完整的所有数据，而不是流式读取接口，
+  // 所以即便返回 InfluxDBQueryRowStream 也不是真正的流式读取
   private TaskExecuteResult buildQueryResult(
       List<FluxTable> tables, Project project, Filter filter, List<String> bucketNames) {
     try (InfluxDBQueryRowStream rowStream =


### PR DESCRIPTION
为了解决以下 PR 在测试 InfluxDB 数据源的 TPC-H 负载时，卡死在 q19 的问题：
- https://github.com/IGinX-THU/IGinX/pull/514
- https://github.com/IGinX-THU/IGinX/pull/607

InfluxDB 对接层返回的 InfluxDBQueryRowStream 持有完整的 FluxTable 对象，在消耗完毕 InfluxDBQueryRowStream 之前，FluxTable 不会得到释放。https://github.com/IGinX-THU/IGinX/pull/514 改为使用流批式的执行引擎，无法尽快释放 InfluxDBQueryRowStream 持有的 FluxTable 对象，导致 OOM 或内存不足引起的执行缓慢。