### PR TITLE
fix: setting $JAVA properly in shell script

### DIFF
--- a/client/src/assembly/resources/sbin/start_cli.sh
+++ b/client/src/assembly/resources/sbin/start_cli.sh
@@ -61,7 +61,8 @@ if [ -n "$JAVA_HOME" ]; then
       break
     fi
   done
-else
+fi
+if [[ -z "${JAVA// /}" ]]; then
   JAVA=java
 fi
 

--- a/core/src/assembly/resources/sbin/start_iginx.bat
+++ b/core/src/assembly/resources/sbin/start_iginx.bat
@@ -87,7 +87,6 @@ for %%i in (%*) do (
 if NOT DEFINED MAIN_CLASS set MAIN_CLASS=cn.edu.tsinghua.iginx.Iginx
 if NOT DEFINED JAVA_HOME goto :err
 
-
 @REM -----------------------------------------------------------------------------
 @REM Compute Memory for JVM configurations
 

--- a/core/src/assembly/resources/sbin/start_iginx.sh
+++ b/core/src/assembly/resources/sbin/start_iginx.sh
@@ -64,7 +64,8 @@ if [ -n "$JAVA_HOME" ]; then
       break
     fi
   done
-else
+fi
+if [[ -z "${JAVA// /}" ]]; then
   JAVA=java
 fi
 


### PR DESCRIPTION
In case that no $JAVA_HOME is set but java can be `exec` directly, $JAVA must be set properly. 