### PR TITLE
fix(relational): do not install dameng jdbc driver if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ hs_err_pid*
 *.DS_Store
 
 **/.flattened-pom.xml
+/dependency/src/main/resources/dameng-jdbc-1.8-SNAPSHOT.jar

--- a/dependency/pom.xml
+++ b/dependency/pom.xml
@@ -58,8 +58,7 @@
                                 <phase>initialize</phase>
                                 <configuration>
                                     <target>
-                                        <mkdir dir="${project.build.directory}/lib"/>
-                                        <get dest="${project.build.directory}/lib/dameng-jdbc-1.8-SNAPSHOT.jar" src="https://raw.githubusercontent.com/IGinX-THU/IGinX-resources/main/resources/dameng-jdbc-1.8-SNAPSHOT.jar" verbose="true"/>
+                                        <get dest="src/main/resources/dameng-jdbc-1.8-SNAPSHOT.jar" ignoreerrors="false" skipexisting="true" src="https://raw.githubusercontent.com/IGinX-THU/IGinX-resources/main/resources/dameng-jdbc-1.8-SNAPSHOT.jar" usetimestamp="true" verbose="true"/>
                                     </target>
                                 </configuration>
                             </execution>
@@ -77,7 +76,7 @@
                                 </goals>
                                 <phase>generate-sources</phase>
                                 <configuration>
-                                    <file>${project.build.directory}/lib/dameng-jdbc-1.8-SNAPSHOT.jar</file>
+                                    <file>src/main/resources/dameng-jdbc-1.8-SNAPSHOT.jar</file>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
编译时如果本地已有达梦jdbc驱动的缓存，则不下载，直接使用