### PR TITLE
refactor(start_iginx.bat): use 'powershell' replacing 'wmic' in start_iginx.bat

### DIFF
--- a/core/src/assembly/resources/sbin/start_iginx.bat
+++ b/core/src/assembly/resources/sbin/start_iginx.bat
@@ -93,10 +93,7 @@ if NOT DEFINED JAVA_HOME goto :err
 if ["%system_cpu_cores%"] LSS ["1"] set system_cpu_cores="1"
 
 set liner=0
-for /f  %%b in ('wmic ComputerSystem get TotalPhysicalMemory') do (
-	set /a liner+=1
-	if !liner!==2 set system_memory=%%b
-)
+for /f "tokens=*" %%a in ('powershell -NoProfile -Command "Get-CimInstance Win32_ComputerSystem | %% { $_.TotalPhysicalMemory }"') do set system_memory=%%a
 
 echo wsh.echo FormatNumber(cdbl(%system_memory%)/(1024*1024), 0) > %temp%\tmp.vbs
 for /f "tokens=*" %%a in ('cscript //nologo %temp%\tmp.vbs') do set system_memory_in_mb=%%a


### PR DESCRIPTION
 "start_iginx.bat" 依赖 wmic，但是 wmic 在 windows 11 24h2中默认删除了，会导致 IGinX 启动失败。可以使用powershell代替wmic实现相同功能。