### PR TITLE
fix(transform): clear batch input cache after each scheduled run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,190 +11,190 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    #    unit-test:
-    #        uses: ./.github/workflows/unit-test.yml
-    #    unit-mds:
-    #        uses: ./.github/workflows/unit-mds.yml
-    #    case-regression:
-    #        uses: ./.github/workflows/case-regression.yml
-    #        with:
-    #            metadata-matrix: '["zookeeper"]'
-    #    standalone-test:
-    #        uses: ./.github/workflows/standalone-test.yml
-    #        with:
-    #            metadata-matrix: '["zookeeper"]'
-    #    standalone-test-no-optimizer:
-    #        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-    #        with:
-    #            metadata-matrix: '["zookeeper"]'
+    unit-test:
+        uses: ./.github/workflows/unit-test.yml
+    unit-mds:
+        uses: ./.github/workflows/unit-mds.yml
+    case-regression:
+        uses: ./.github/workflows/case-regression.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    standalone-test:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    standalone-test-no-optimizer:
+        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
     db-ce:
         uses: ./.github/workflows/DB-CE.yml
         with:
             metadata-matrix: '["zookeeper"]'
-#    db-ce-no-optimizer:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            close-optimizer: "true"
-#    standalone-test-no-mac-relational:
-#        uses: ./.github/workflows/standalone-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng", "Oracle"]'
-#            timeout-minutes: 100
-#    standalone-test-no-optimizer-no-mac-relational:
-#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng", "Oracle"]'
-#            timeout-minutes: 100
-#    standalone-test-no-mac-no-privs-dameng:
-#        uses: ./.github/workflows/standalone-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng"]'
-#            db-support-create-database: false
-#            timeout-minutes: 120
-#    standalone-test-no-optimizer-no-mac-no-privs-dameng:
-#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng"]'
-#            db-support-create-database: false
-#            timeout-minutes: 100
-#    standalone-test-oceanbase:
-#        uses: ./.github/workflows/standalone-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest"]'
-#            db-matrix: '["OceanBase"]'
-#            timeout-minutes: 300
-#    standalone-test-no-optimizer-oceanbase:
-#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest"]'
-#            db-matrix: '["OceanBase"]'
-#            timeout-minutes: 300
-#    db-ce-dameng:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 120
-#    db-ce-no-optimizer-dameng:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["Dameng"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 120
-#            close-optimizer: "true"
-#    db-ce-only-linux-relational:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest"]'
-#            db-matrix: '["Oracle", "OceanBase"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 120
-#    db-ce-no-optimizer-only-linux-relational:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest"]'
-#            db-matrix: '["Oracle", "OceanBase"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 120
-#            close-optimizer: "true"
-#    standalone-test-vectordb:
-#        uses: ./.github/workflows/standalone-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["VectorDB"]'
-#            timeout-minutes: 300
-#    standalone-test-no-optimizer-vectordb:
-#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["VectorDB"]'
-#            timeout-minutes: 300
-#    db-ce-vectordb:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["VectorDB"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 360
-#    db-ce-no-optimizer-vectordb:
-#        uses: ./.github/workflows/DB-CE.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#            os-matrix: '["ubuntu-latest", "windows-latest"]'
-#            db-matrix: '["VectorDB"]'
-#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-#            timeout-minutes: 360
-#            close-optimizer: "true"
-#    remote-test:
-#        uses: ./.github/workflows/remote-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#    assembly-test:
-#        uses: ./.github/workflows/assembly-test.yml
-#    free-thread-test:
-#        uses: ./.github/workflows/free-thread-test.yml
-#        with:
-#            metadata-matrix: '["zookeeper"]'
-#    tpc-h-test:
-#        uses: ./.github/workflows/tpc-h.yml
-#        with:
-#            os-matrix: '["ubuntu-latest"]'
-#            metadata-matrix: '["zookeeper"]'
-#    cluster-test:
-#        uses: ./.github/workflows/cluster-test.yml
-#    restart-test:
-#        uses: ./.github/workflows/restart-test.yml
-#    analyze-required-test-check:
-#        if: always()
-#        needs: # List of jobs that must pass. Add more jobs if needed.
-#            - unit-test
-#            - unit-mds
-#            - case-regression
-#            - standalone-test
-#            - standalone-test-no-optimizer
-#            - db-ce
-#            - db-ce-no-optimizer
-#            - standalone-test-vectordb
-#            - standalone-test-no-optimizer-vectordb
-#            - db-ce-vectordb
-#            - db-ce-no-optimizer-vectordb
-#            - remote-test
-#            - assembly-test
-#            - free-thread-test
-#            - tpc-h-test
-#            - standalone-test-no-mac-relational
-#            - standalone-test-no-optimizer-no-mac-relational
-#            - db-ce-dameng
-#            - db-ce-no-optimizer-dameng
-#            - db-ce-only-linux-relational
-#            - db-ce-no-optimizer-only-linux-relational
-#            - standalone-test-oceanbase
-#            - standalone-test-no-optimizer-oceanbase
-#            - cluster-test
-#            - restart-test
-#        runs-on: ubuntu-latest
-#        steps:
-#            - name: Decide whether the needed jobs succeeded or failed
-#              uses: re-actors/alls-green@release/v1
-#              with:
-#                  jobs: ${{ toJSON(needs) }}
+    db-ce-no-optimizer:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            close-optimizer: "true"
+    standalone-test-no-mac-relational:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng", "Oracle"]'
+            timeout-minutes: 100
+    standalone-test-no-optimizer-no-mac-relational:
+        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng", "Oracle"]'
+            timeout-minutes: 100
+    standalone-test-no-mac-no-privs-dameng:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng"]'
+            db-support-create-database: false
+            timeout-minutes: 120
+    standalone-test-no-optimizer-no-mac-no-privs-dameng:
+        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng"]'
+            db-support-create-database: false
+            timeout-minutes: 100
+    standalone-test-oceanbase:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest"]'
+            db-matrix: '["OceanBase"]'
+            timeout-minutes: 300
+    standalone-test-no-optimizer-oceanbase:
+        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest"]'
+            db-matrix: '["OceanBase"]'
+            timeout-minutes: 300
+    db-ce-dameng:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 120
+    db-ce-no-optimizer-dameng:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["Dameng"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 120
+            close-optimizer: "true"
+    db-ce-only-linux-relational:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest"]'
+            db-matrix: '["Oracle", "OceanBase"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 120
+    db-ce-no-optimizer-only-linux-relational:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest"]'
+            db-matrix: '["Oracle", "OceanBase"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 120
+            close-optimizer: "true"
+    standalone-test-vectordb:
+        uses: ./.github/workflows/standalone-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["VectorDB"]'
+            timeout-minutes: 300
+    standalone-test-no-optimizer-vectordb:
+        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["VectorDB"]'
+            timeout-minutes: 300
+    db-ce-vectordb:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["VectorDB"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 360
+    db-ce-no-optimizer-vectordb:
+        uses: ./.github/workflows/DB-CE.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+            os-matrix: '["ubuntu-latest", "windows-latest"]'
+            db-matrix: '["VectorDB"]'
+            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+            timeout-minutes: 360
+            close-optimizer: "true"
+    remote-test:
+        uses: ./.github/workflows/remote-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    assembly-test:
+        uses: ./.github/workflows/assembly-test.yml
+    free-thread-test:
+        uses: ./.github/workflows/free-thread-test.yml
+        with:
+            metadata-matrix: '["zookeeper"]'
+    tpc-h-test:
+        uses: ./.github/workflows/tpc-h.yml
+        with:
+            os-matrix: '["ubuntu-latest"]'
+            metadata-matrix: '["zookeeper"]'
+    cluster-test:
+        uses: ./.github/workflows/cluster-test.yml
+    restart-test:
+        uses: ./.github/workflows/restart-test.yml
+    analyze-required-test-check:
+        if: always()
+        needs: # List of jobs that must pass. Add more jobs if needed.
+            - unit-test
+            - unit-mds
+            - case-regression
+            - standalone-test
+            - standalone-test-no-optimizer
+            - db-ce
+            - db-ce-no-optimizer
+            - standalone-test-vectordb
+            - standalone-test-no-optimizer-vectordb
+            - db-ce-vectordb
+            - db-ce-no-optimizer-vectordb
+            - remote-test
+            - assembly-test
+            - free-thread-test
+            - tpc-h-test
+            - standalone-test-no-mac-relational
+            - standalone-test-no-optimizer-no-mac-relational
+            - db-ce-dameng
+            - db-ce-no-optimizer-dameng
+            - db-ce-only-linux-relational
+            - db-ce-no-optimizer-only-linux-relational
+            - standalone-test-oceanbase
+            - standalone-test-no-optimizer-oceanbase
+            - cluster-test
+            - restart-test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Decide whether the needed jobs succeeded or failed
+              uses: re-actors/alls-green@release/v1
+              with:
+                  jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,190 +11,190 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    unit-test:
-        uses: ./.github/workflows/unit-test.yml
-    unit-mds:
-        uses: ./.github/workflows/unit-mds.yml
-    case-regression:
-        uses: ./.github/workflows/case-regression.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    standalone-test:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    standalone-test-no-optimizer:
-        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
+    #    unit-test:
+    #        uses: ./.github/workflows/unit-test.yml
+    #    unit-mds:
+    #        uses: ./.github/workflows/unit-mds.yml
+    #    case-regression:
+    #        uses: ./.github/workflows/case-regression.yml
+    #        with:
+    #            metadata-matrix: '["zookeeper"]'
+    #    standalone-test:
+    #        uses: ./.github/workflows/standalone-test.yml
+    #        with:
+    #            metadata-matrix: '["zookeeper"]'
+    #    standalone-test-no-optimizer:
+    #        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+    #        with:
+    #            metadata-matrix: '["zookeeper"]'
     db-ce:
         uses: ./.github/workflows/DB-CE.yml
         with:
             metadata-matrix: '["zookeeper"]'
-    db-ce-no-optimizer:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            close-optimizer: "true"
-    standalone-test-no-mac-relational:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng", "Oracle"]'
-            timeout-minutes: 100
-    standalone-test-no-optimizer-no-mac-relational:
-        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng", "Oracle"]'
-            timeout-minutes: 100
-    standalone-test-no-mac-no-privs-dameng:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng"]'
-            db-support-create-database: false
-            timeout-minutes: 120
-    standalone-test-no-optimizer-no-mac-no-privs-dameng:
-        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng"]'
-            db-support-create-database: false
-            timeout-minutes: 100
-    standalone-test-oceanbase:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest"]'
-            db-matrix: '["OceanBase"]'
-            timeout-minutes: 300
-    standalone-test-no-optimizer-oceanbase:
-        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest"]'
-            db-matrix: '["OceanBase"]'
-            timeout-minutes: 300
-    db-ce-dameng:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 120
-    db-ce-no-optimizer-dameng:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["Dameng"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 120
-            close-optimizer: "true"
-    db-ce-only-linux-relational:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest"]'
-            db-matrix: '["Oracle", "OceanBase"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 120
-    db-ce-no-optimizer-only-linux-relational:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest"]'
-            db-matrix: '["Oracle", "OceanBase"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 120
-            close-optimizer: "true"
-    standalone-test-vectordb:
-        uses: ./.github/workflows/standalone-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["VectorDB"]'
-            timeout-minutes: 300
-    standalone-test-no-optimizer-vectordb:
-        uses: ./.github/workflows/standalone-test-no-optimizer.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["VectorDB"]'
-            timeout-minutes: 300
-    db-ce-vectordb:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["VectorDB"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 360
-    db-ce-no-optimizer-vectordb:
-        uses: ./.github/workflows/DB-CE.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-            os-matrix: '["ubuntu-latest", "windows-latest"]'
-            db-matrix: '["VectorDB"]'
-            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
-            timeout-minutes: 360
-            close-optimizer: "true"
-    remote-test:
-        uses: ./.github/workflows/remote-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    assembly-test:
-        uses: ./.github/workflows/assembly-test.yml
-    free-thread-test:
-        uses: ./.github/workflows/free-thread-test.yml
-        with:
-            metadata-matrix: '["zookeeper"]'
-    tpc-h-test:
-        uses: ./.github/workflows/tpc-h.yml
-        with:
-            os-matrix: '["ubuntu-latest"]'
-            metadata-matrix: '["zookeeper"]'
-    cluster-test:
-        uses: ./.github/workflows/cluster-test.yml
-    restart-test:
-        uses: ./.github/workflows/restart-test.yml
-    analyze-required-test-check:
-        if: always()
-        needs: # List of jobs that must pass. Add more jobs if needed.
-            - unit-test
-            - unit-mds
-            - case-regression
-            - standalone-test
-            - standalone-test-no-optimizer
-            - db-ce
-            - db-ce-no-optimizer
-            - standalone-test-vectordb
-            - standalone-test-no-optimizer-vectordb
-            - db-ce-vectordb
-            - db-ce-no-optimizer-vectordb
-            - remote-test
-            - assembly-test
-            - free-thread-test
-            - tpc-h-test
-            - standalone-test-no-mac-relational
-            - standalone-test-no-optimizer-no-mac-relational
-            - db-ce-dameng
-            - db-ce-no-optimizer-dameng
-            - db-ce-only-linux-relational
-            - db-ce-no-optimizer-only-linux-relational
-            - standalone-test-oceanbase
-            - standalone-test-no-optimizer-oceanbase
-            - cluster-test
-            - restart-test
-        runs-on: ubuntu-latest
-        steps:
-            - name: Decide whether the needed jobs succeeded or failed
-              uses: re-actors/alls-green@release/v1
-              with:
-                  jobs: ${{ toJSON(needs) }}
+#    db-ce-no-optimizer:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            close-optimizer: "true"
+#    standalone-test-no-mac-relational:
+#        uses: ./.github/workflows/standalone-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng", "Oracle"]'
+#            timeout-minutes: 100
+#    standalone-test-no-optimizer-no-mac-relational:
+#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng", "Oracle"]'
+#            timeout-minutes: 100
+#    standalone-test-no-mac-no-privs-dameng:
+#        uses: ./.github/workflows/standalone-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng"]'
+#            db-support-create-database: false
+#            timeout-minutes: 120
+#    standalone-test-no-optimizer-no-mac-no-privs-dameng:
+#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng"]'
+#            db-support-create-database: false
+#            timeout-minutes: 100
+#    standalone-test-oceanbase:
+#        uses: ./.github/workflows/standalone-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest"]'
+#            db-matrix: '["OceanBase"]'
+#            timeout-minutes: 300
+#    standalone-test-no-optimizer-oceanbase:
+#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest"]'
+#            db-matrix: '["OceanBase"]'
+#            timeout-minutes: 300
+#    db-ce-dameng:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 120
+#    db-ce-no-optimizer-dameng:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["Dameng"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 120
+#            close-optimizer: "true"
+#    db-ce-only-linux-relational:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest"]'
+#            db-matrix: '["Oracle", "OceanBase"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 120
+#    db-ce-no-optimizer-only-linux-relational:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest"]'
+#            db-matrix: '["Oracle", "OceanBase"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 120
+#            close-optimizer: "true"
+#    standalone-test-vectordb:
+#        uses: ./.github/workflows/standalone-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["VectorDB"]'
+#            timeout-minutes: 300
+#    standalone-test-no-optimizer-vectordb:
+#        uses: ./.github/workflows/standalone-test-no-optimizer.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["VectorDB"]'
+#            timeout-minutes: 300
+#    db-ce-vectordb:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["VectorDB"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 360
+#    db-ce-no-optimizer-vectordb:
+#        uses: ./.github/workflows/DB-CE.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#            os-matrix: '["ubuntu-latest", "windows-latest"]'
+#            db-matrix: '["VectorDB"]'
+#            functest: "NewSessionIT,SQLCompareIT,TagIT,RestIT,TransformIT,UDFIT,RestAnnotationIT,SQLSessionIT,SQLSessionPoolIT,SessionV2IT,CompactionIT,TimePrecisionIT,PySessionIT"
+#            timeout-minutes: 360
+#            close-optimizer: "true"
+#    remote-test:
+#        uses: ./.github/workflows/remote-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#    assembly-test:
+#        uses: ./.github/workflows/assembly-test.yml
+#    free-thread-test:
+#        uses: ./.github/workflows/free-thread-test.yml
+#        with:
+#            metadata-matrix: '["zookeeper"]'
+#    tpc-h-test:
+#        uses: ./.github/workflows/tpc-h.yml
+#        with:
+#            os-matrix: '["ubuntu-latest"]'
+#            metadata-matrix: '["zookeeper"]'
+#    cluster-test:
+#        uses: ./.github/workflows/cluster-test.yml
+#    restart-test:
+#        uses: ./.github/workflows/restart-test.yml
+#    analyze-required-test-check:
+#        if: always()
+#        needs: # List of jobs that must pass. Add more jobs if needed.
+#            - unit-test
+#            - unit-mds
+#            - case-regression
+#            - standalone-test
+#            - standalone-test-no-optimizer
+#            - db-ce
+#            - db-ce-no-optimizer
+#            - standalone-test-vectordb
+#            - standalone-test-no-optimizer-vectordb
+#            - db-ce-vectordb
+#            - db-ce-no-optimizer-vectordb
+#            - remote-test
+#            - assembly-test
+#            - free-thread-test
+#            - tpc-h-test
+#            - standalone-test-no-mac-relational
+#            - standalone-test-no-optimizer-no-mac-relational
+#            - db-ce-dameng
+#            - db-ce-no-optimizer-dameng
+#            - db-ce-only-linux-relational
+#            - db-ce-no-optimizer-only-linux-relational
+#            - standalone-test-oceanbase
+#            - standalone-test-no-optimizer-oceanbase
+#            - cluster-test
+#            - restart-test
+#        runs-on: ubuntu-latest
+#        steps:
+#            - name: Decide whether the needed jobs succeeded or failed
+#              uses: re-actors/alls-green@release/v1
+#              with:
+#                  jobs: ${{ toJSON(needs) }}

--- a/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/BatchStageRunner.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/BatchStageRunner.java
@@ -70,6 +70,7 @@ public class BatchStageRunner implements Runner {
     CollectionWriter collectionWriter =
         (CollectionWriter) batchStage.getBeforeStage().getExportWriter();
     BatchData batchData = collectionWriter.getCollectedData();
+    collectionWriter.reset();
 
     mutex.lock();
     writer.writeBatch(batchData);

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
@@ -438,21 +438,14 @@ public class TransformIT {
       }
 
       session.executeSql("INSERT INTO scheduleBatchBug(key, s1, s2) VALUES (1, 1, 2);");
+      session.executeSql("INSERT INTO scheduleBatchBug(key, s1, s2) VALUES (2, 10, 20);");
 
       String yamlFileName =
           OUTPUT_DIR_PREFIX + File.separator + "TransformScheduledBatchTransformBug.yaml";
       long jobId = session.commitTransformJob(String.format(COMMIT_SQL_FORMATTER, yamlFileName));
       try {
-        Thread.sleep(3000L); // wait for the first scheduled run to finish
-        verifyScheduledBatchBugResult(1, 1L, 3L);
-
-        session.executeSql("INSERT INTO scheduleBatchBug(key, s1, s2) VALUES (1, 10, 20);");
-
-        verifyJobState(jobId, null);
-        verifyJobState(jobId, JobState.JOB_IDLE);
-
-        Thread.sleep(10000L); // wait for the second scheduled run to finish
-        verifyScheduledBatchBugResult(2, 1L, 30L);
+        Thread.sleep(5000L); // wait for the scheduled job to run at least twice
+        verifyScheduledBatchBugResult(33L);
       } finally {
         cancelJob(jobId);
       }
@@ -811,26 +804,28 @@ public class TransformIT {
     assertEquals(lineCount, index);
   }
 
-  private void verifyScheduledBatchBugResult(
-      int expectedRowCount, long expectedLastKey, long expectedLastSum) throws SessionException {
+  private void verifyScheduledBatchBugResult(long expectedSum) throws SessionException {
     SessionExecuteSqlResult queryResult = session.executeSql("SELECT * FROM transform;");
     int timeIndex = queryResult.getPaths().indexOf("transform.key");
     int sumIndex = queryResult.getPaths().indexOf("transform.sum");
+    LOGGER.info("Scheduled batch bug query paths: {}", queryResult.getPaths());
+    LOGGER.info("Scheduled batch bug query returned {} row(s).", queryResult.getValues().size());
+    for (int i = 0; i < queryResult.getValues().size(); i++) {
+      List<Object> row = queryResult.getValues().get(i);
+      Object keyValue = timeIndex >= 0 ? row.get(timeIndex) : "N/A";
+      Object sumValue = sumIndex >= 0 ? row.get(sumIndex) : "N/A";
+      LOGGER.info(
+          "Scheduled batch bug result row[{}]: key={}, sum={}, raw={}", i, keyValue, sumValue, row);
+    }
     if (needCompareResult) {
       assertNotEquals(-1, timeIndex);
       assertNotEquals(-1, sumIndex);
     }
 
-    assertEquals(expectedRowCount, queryResult.getValues().size());
-
-    List<Object> lastRow = queryResult.getValues().get(queryResult.getValues().size() - 1);
-    if (expectedRowCount > 1) {
-      List<Object> firstRow = queryResult.getValues().get(0);
-      assertEquals(1L, firstRow.get(timeIndex));
-      assertEquals(3L, firstRow.get(sumIndex));
+    assertTrue(queryResult.getValues().size() >= 2);
+    for (List<Object> row : queryResult.getValues()) {
+      assertEquals(expectedSum, row.get(sumIndex));
     }
-    assertEquals(expectedLastKey, lastRow.get(timeIndex));
-    assertEquals(expectedLastSum, lastRow.get(sumIndex));
   }
 
   // have to modify file content because UDF script name is usually not allowed to change

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
@@ -808,8 +808,6 @@ public class TransformIT {
     SessionExecuteSqlResult queryResult = session.executeSql("SELECT * FROM transform;");
     int timeIndex = queryResult.getPaths().indexOf("transform.key");
     int sumIndex = queryResult.getPaths().indexOf("transform.sum");
-    LOGGER.info("Scheduled batch bug query paths: {}", queryResult.getPaths());
-    LOGGER.info("Scheduled batch bug query returned {} row(s).", queryResult.getValues().size());
     for (int i = 0; i < queryResult.getValues().size(); i++) {
       List<Object> row = queryResult.getValues().get(i);
       Object keyValue = timeIndex >= 0 ? row.get(timeIndex) : "N/A";

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
@@ -429,6 +429,40 @@ public class TransformIT {
   }
 
   @Test
+  public void commitScheduledBatchTransformShouldNotReusePreviousInputTest() {
+    LOGGER.info("commitScheduledBatchTransformShouldNotReusePreviousInputTest");
+    try {
+      String[] taskList = {"RowSumTransformer", "SumTransformer"};
+      for (String task : taskList) {
+        registerTask(task);
+      }
+
+      session.executeSql("INSERT INTO scheduleBatchBug(key, s1, s2) VALUES (1, 1, 2);");
+
+      String yamlFileName =
+          OUTPUT_DIR_PREFIX + File.separator + "TransformScheduledBatchTransformBug.yaml";
+      long jobId = session.commitTransformJob(String.format(COMMIT_SQL_FORMATTER, yamlFileName));
+      try {
+        Thread.sleep(3000L); // wait for the first scheduled run to finish
+        verifyScheduledBatchBugResult(1, 1L, 3L);
+
+        session.executeSql("INSERT INTO scheduleBatchBug(key, s1, s2) VALUES (1, 10, 20);");
+
+        verifyJobState(jobId, null);
+        verifyJobState(jobId, JobState.JOB_IDLE);
+
+        Thread.sleep(10000L); // wait for the second scheduled run to finish
+        verifyScheduledBatchBugResult(2, 1L, 30L);
+      } finally {
+        cancelJob(jobId);
+      }
+    } catch (SessionException | InterruptedException e) {
+      LOGGER.error("Transform:  execute fail. Caused by:", e);
+      fail();
+    }
+  }
+
+  @Test
   public void commitStopOnFailureTest() {
     LOGGER.info("commitStopOnFailureTest");
     try {
@@ -775,6 +809,28 @@ public class TransformIT {
       index++;
     }
     assertEquals(lineCount, index);
+  }
+
+  private void verifyScheduledBatchBugResult(
+      int expectedRowCount, long expectedLastKey, long expectedLastSum) throws SessionException {
+    SessionExecuteSqlResult queryResult = session.executeSql("SELECT * FROM transform;");
+    int timeIndex = queryResult.getPaths().indexOf("transform.key");
+    int sumIndex = queryResult.getPaths().indexOf("transform.sum");
+    if (needCompareResult) {
+      assertNotEquals(-1, timeIndex);
+      assertNotEquals(-1, sumIndex);
+    }
+
+    assertEquals(expectedRowCount, queryResult.getValues().size());
+
+    List<Object> lastRow = queryResult.getValues().get(queryResult.getValues().size() - 1);
+    if (expectedRowCount > 1) {
+      List<Object> firstRow = queryResult.getValues().get(0);
+      assertEquals(1L, firstRow.get(timeIndex));
+      assertEquals(3L, firstRow.get(sumIndex));
+    }
+    assertEquals(expectedLastKey, lastRow.get(timeIndex));
+    assertEquals(expectedLastSum, lastRow.get(sumIndex));
   }
 
   // have to modify file content because UDF script name is usually not allowed to change

--- a/test/src/test/resources/transform/TransformScheduledBatchTransformBug.yaml
+++ b/test/src/test/resources/transform/TransformScheduledBatchTransformBug.yaml
@@ -3,7 +3,7 @@ taskList:
 - taskType: "sql"
   timeout: 10000000
   sqlList:
-  - "SELECT s1, s2 FROM scheduleBatchBug WHERE key <= 1;"
+  - "SELECT s1, s2 FROM scheduleBatchBug WHERE key <= 2;"
 - taskType: "python"
   dataFlowType: "batch"
   timeout: 10000000
@@ -12,5 +12,5 @@ taskList:
   dataFlowType: "stream"
   timeout: 10000000
   pyTaskName: "RowSumTransformer"
-schedule: "every 10 second"
+schedule: "every 2 second"
 exportType: "iginx"

--- a/test/src/test/resources/transform/TransformScheduledBatchTransformBug.yaml
+++ b/test/src/test/resources/transform/TransformScheduledBatchTransformBug.yaml
@@ -1,0 +1,16 @@
+---
+taskList:
+- taskType: "sql"
+  timeout: 10000000
+  sqlList:
+  - "SELECT s1, s2 FROM scheduleBatchBug WHERE key <= 1;"
+- taskType: "python"
+  dataFlowType: "batch"
+  timeout: 10000000
+  pyTaskName: "SumTransformer"
+- taskType: "python"
+  dataFlowType: "stream"
+  timeout: 10000000
+  pyTaskName: "RowSumTransformer"
+schedule: "every 10 second"
+exportType: "iginx"


### PR DESCRIPTION
This PR fixes a bug in scheduled batch transform jobs.

Before this change, the input cached by CollectionWriter was not cleared after a batch stage finished. Because of that, data from previous scheduled runs could be reused in later runs, which caused duplicated input and incorrect transform results.

This PR resets the cached batch input after it is consumed by BatchStageRunner, so each scheduled run only processes newly collected data.

A new integration test was also added to reproduce this issue. The test uses fixed input data:
(key=1, s1=1, s2=2) and (key=2, s1=10, s2=20).
The job first runs SumTransformer in batch mode, which should produce one row with key=3, s1=11, s2=22. Then it runs RowSumTransformer in stream mode, which should produce key=3, sum=33.
Because the source data does not change, every scheduled run should produce the same final result: sum=33.
Before this fix, later runs incorrectly reused old batch input and produced accumulated results like:
[3, 33], [6, 66], [9, 99]
instead of keeping each run's result at 33.