### PR TITLE
fix(transform): isolate scheduled job cancellation

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/JobRunner.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/JobRunner.java
@@ -47,6 +47,8 @@ public class JobRunner implements Runner {
 
   private Scheduler scheduler;
 
+  private JobKey jobKey;
+
   public JobRunner(Job job) {
     this.job = job;
     this.runnerList = new ArrayList<>();
@@ -71,6 +73,7 @@ public class JobRunner implements Runner {
     scheduler = StdSchedulerFactory.getDefaultScheduler();
 
     JobDetail jobDetail = JobBuilder.newJob(ScheduledJob.class).build();
+    jobKey = jobDetail.getKey();
 
     jobDetail.getJobDataMap().put("runnerList", runnerList);
     jobDetail.getJobDataMap().put("job", job);
@@ -113,7 +116,9 @@ public class JobRunner implements Runner {
   @Override
   public void close() {
     try {
-      scheduler.shutdown();
+      if (scheduler != null && jobKey != null) {
+        scheduler.deleteJob(jobKey);
+      }
     } catch (SchedulerException e) {
       LOGGER.error("Fail to close Transform job runner id={}, because", job.getJobId(), e);
     }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
@@ -429,6 +429,70 @@ public class TransformIT {
   }
 
   @Test
+  public void cancelOneScheduledJobDoesNotStopOtherScheduledJobsTest() {
+    LOGGER.info("cancelOneScheduledJobDoesNotStopOtherScheduledJobsTest");
+    String firstOutput =
+        OUTPUT_DIR_PREFIX + File.separator + "export_file_cancel_isolation_first.txt";
+    String secondOutput =
+        OUTPUT_DIR_PREFIX + File.separator + "export_file_cancel_isolation_second.txt";
+    long firstJobId = -1;
+    long secondJobId = -1;
+    boolean firstJobCancelled = false;
+    boolean testPassed = false;
+    try {
+      Files.deleteIfExists(Paths.get(firstOutput));
+      Files.deleteIfExists(Paths.get(secondOutput));
+
+      List<TaskInfo> taskInfoList = new ArrayList<>();
+      TaskInfo sqlTask = new TaskInfo(TaskType.SQL, DataFlowType.STREAM);
+      sqlTask.setSqlList(Collections.singletonList("SELECT s1 FROM us.d1 WHERE key = 0;"));
+      taskInfoList.add(sqlTask);
+
+      firstJobId =
+          session.commitTransformJob(taskInfoList, ExportType.FILE, firstOutput, "every 1 second");
+      secondJobId =
+          session.commitTransformJob(taskInfoList, ExportType.FILE, secondOutput, "every 1 second");
+
+      Thread.sleep(4000L);
+      assertTrue(getFileLineCount(firstOutput) > 1);
+      assertTrue(getFileLineCount(secondOutput) > 1);
+
+      cancelJob(firstJobId);
+      firstJobCancelled = true;
+
+      int firstJobLineCount = getFileLineCount(firstOutput);
+      int secondJobLineCount = getFileLineCount(secondOutput);
+      Thread.sleep(4000L);
+      assertEquals(firstJobLineCount, getFileLineCount(firstOutput));
+      assertTrue(getFileLineCount(secondOutput) > secondJobLineCount);
+      testPassed = true;
+    } catch (SessionException | IOException | InterruptedException e) {
+      LOGGER.error("Transform: execute fail. Caused by:", e);
+      fail();
+    } finally {
+      if (firstJobId > 0 && !firstJobCancelled) {
+        cancelJob(firstJobId);
+      }
+      if (secondJobId > 0) {
+        cancelJob(secondJobId);
+      }
+      if (testPassed) {
+        try {
+          Files.deleteIfExists(Paths.get(firstOutput));
+          Files.deleteIfExists(Paths.get(secondOutput));
+        } catch (IOException e) {
+          LOGGER.error("Fail to delete transform output file.", e);
+          fail();
+        }
+      }
+    }
+  }
+
+  private int getFileLineCount(String filename) throws IOException {
+    return Files.readAllLines(Paths.get(filename)).size();
+  }
+
+  @Test
   public void commitStopOnFailureTest() {
     LOGGER.info("commitStopOnFailureTest");
     try {


### PR DESCRIPTION
## Summary

Prevent cancelling one scheduled Transform job from stopping other scheduled jobs on the same IGinX node.

## Changes

- Store each Quartz `JobDetail` key in `JobRunner`.
- Replace shared `Scheduler.shutdown()` with `Scheduler.deleteJob(jobKey)` when closing a Transform job.
- Add an integration test that verifies:
  - the cancelled job stops writing output;
  - another scheduled job continues writing output;
  - output files are preserved when the test fails for investigation.

## Root Cause

All `JobRunner` instances use Quartz's shared default `Scheduler`. Calling `shutdown()` while cancelling one job stopped every registered trigger in that scheduler.