### PR TITLE
feat(transform): support batch Python output for scheduled jobs and SQL stages

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/BatchStageRunner.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/transform/exec/BatchStageRunner.java
@@ -55,6 +55,7 @@ public class BatchStageRunner implements Runner {
 
   @Override
   public void start() throws TransformException {
+    writer = batchStage.getExportWriter();
     Task task = batchStage.getTask();
     if (task.isPythonTask()) {
       pemjaWorker = driver.createWorker((PythonTask) task, writer);
@@ -70,6 +71,7 @@ public class BatchStageRunner implements Runner {
     CollectionWriter collectionWriter =
         (CollectionWriter) batchStage.getBeforeStage().getExportWriter();
     BatchData batchData = collectionWriter.getCollectedData();
+    collectionWriter.reset();
 
     mutex.lock();
     writer.writeBatch(batchData);

--- a/core/src/main/java/cn/edu/tsinghua/iginx/transform/pojo/Job.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/transform/pojo/Job.java
@@ -127,11 +127,21 @@ public class Job {
           stageList.add(stage);
           stageTasks.clear();
         }
+        ExportWriter batchWriter = new CollectionWriter();
         if (i == req.getTaskListSize() - 1) {
-          stage = new BatchStage(stage, task, writer);
-        } else {
-          stage = new BatchStage(stage, task, new CollectionWriter());
+          batchWriter = writer;
+        } else if (i + 1 < req.getTaskListSize()) {
+          TaskInfo nextInfo = req.getTaskList().get(i + 1);
+          if (nextInfo.getTaskType().equals(TaskType.SQL)
+              && task.isPythonTask()
+              && ((PythonTask) task).isSetOutputPrefix()) {
+            String outputPrefix = ((PythonTask) task).getOutputPrefix();
+            pyTables.add(outputPrefix);
+            batchWriter = new IginXWriter(sessionId, outputPrefix);
+            tempTableUsed = true;
+          }
         }
+        stage = new BatchStage(stage, task, batchWriter);
         stageList.add(stage);
       } else {
         if (task.getTaskType().equals(TaskType.SQL) && !stageTasks.isEmpty()) {

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/func/udf/TransformIT.java
@@ -429,6 +429,100 @@ public class TransformIT {
   }
 
   @Test
+  public void commitScheduledBatchTransformTest() {
+    LOGGER.info("commitScheduledBatchTransformTest");
+    String outputFileName =
+        OUTPUT_DIR_PREFIX + File.separator + "export_file_scheduled_batch_python_job.txt";
+    try {
+      registerTask("AddOneTransformer");
+      registerTask("SumTransformer");
+
+      TaskInfo sqlTask = new TaskInfo(TaskType.SQL, DataFlowType.STREAM);
+      sqlTask.setSqlList(Collections.singletonList(QUERY_SQL_3));
+      TaskInfo addOnePyTask = new TaskInfo(TaskType.PYTHON, DataFlowType.STREAM);
+      addOnePyTask.setPyTaskName("AddOneTransformer");
+      TaskInfo sumPyTask = new TaskInfo(TaskType.PYTHON, DataFlowType.BATCH);
+      sumPyTask.setPyTaskName("SumTransformer");
+
+      long jobId =
+          session.commitTransformJob(
+              Arrays.asList(sqlTask, addOnePyTask, sumPyTask),
+              ExportType.FILE,
+              outputFileName,
+              "every 10 second");
+      try {
+        Thread.sleep(3000L);
+        fileResultContains(outputFileName, "55,55,65");
+        verifyJobState(jobId, JobState.JOB_IDLE);
+        Thread.sleep(10000L);
+        verifyRepeatedFileResult(outputFileName, "55,55,65", 2);
+      } finally {
+        cancelJob(jobId);
+      }
+    } catch (SessionException | InterruptedException e) {
+      LOGGER.error("Transform: execute fail. Caused by:", e);
+      fail();
+    } finally {
+      try {
+        assertTrue(Files.deleteIfExists(Paths.get(outputFileName)));
+      } catch (IOException e) {
+        LOGGER.error("Fail to delete result file: {}", outputFileName, e);
+        fail();
+      }
+    }
+  }
+
+  @Test
+  public void commitBatchTransformWithTemporaryTableTest() {
+    LOGGER.info("commitBatchTransformWithTemporaryTableTest");
+    String outputFileName =
+        OUTPUT_DIR_PREFIX
+            + File.separator
+            + "export_file_batch_python_job_with_temporary_table.txt";
+    try {
+      registerTask("AddOneTransformer");
+      registerTask("SumTransformer");
+
+      TaskInfo sqlTask = new TaskInfo(TaskType.SQL, DataFlowType.STREAM);
+      sqlTask.setSqlList(Collections.singletonList(QUERY_SQL_3));
+      TaskInfo addOneTask = new TaskInfo(TaskType.PYTHON, DataFlowType.STREAM);
+      addOneTask.setPyTaskName("AddOneTransformer");
+      TaskInfo sumTask = new TaskInfo(TaskType.PYTHON, DataFlowType.BATCH);
+      sumTask.setPyTaskName("SumTransformer");
+      sumTask.setOutputPrefix("batchsum");
+      TaskInfo temporaryTableSqlTask = new TaskInfo(TaskType.SQL, DataFlowType.STREAM);
+      temporaryTableSqlTask.setSqlList(Collections.singletonList("SELECT * FROM batchsum;"));
+
+      long jobId =
+          session.commitTransformJob(
+              Arrays.asList(sqlTask, addOneTask, sumTask, temporaryTableSqlTask),
+              ExportType.FILE,
+              outputFileName);
+      verifyJobFinishedBlocked(jobId);
+      if (needCompareResult) {
+        List<String> lines = Files.readAllLines(Paths.get(outputFileName));
+        assertEquals(2, lines.size());
+        String[] values = lines.get(1).split(",", -1);
+        assertEquals(4, values.length);
+        Long.parseLong(values[0]);
+        assertEquals("55", values[1]);
+        assertEquals("55", values[2]);
+        assertEquals("65", values[3]);
+      }
+    } catch (SessionException | InterruptedException | IOException e) {
+      LOGGER.error("Transform: execute fail. Caused by:", e);
+      fail();
+    } finally {
+      try {
+        assertTrue(Files.deleteIfExists(Paths.get(outputFileName)));
+      } catch (IOException e) {
+        LOGGER.error("Fail to delete result file: {}", outputFileName, e);
+        fail();
+      }
+    }
+  }
+
+  @Test
   public void commitStopOnFailureTest() {
     LOGGER.info("commitStopOnFailureTest");
     try {
@@ -1295,6 +1389,22 @@ public class TransformIT {
       fail();
     }
     assertTrue(contains);
+  }
+
+  private void verifyRepeatedFileResult(String filename, String content, int expectedCount) {
+    int count = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(content)) {
+          count++;
+        }
+      }
+    } catch (IOException e) {
+      LOGGER.error("Verify repeated file export result failed.", e);
+      fail();
+    }
+    assertEquals(expectedCount, count);
   }
 
   @Rule public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTPS);


### PR DESCRIPTION
## Summary

- Reset the Batch Transform writer before every scheduled execution.
- Clear the upstream `CollectionWriter` buffer after Batch Transform reads its input.
- Support writing Batch Python output to a temporary table when a SQL task follows.
- Add integration coverage for scheduled Batch Transform execution and Batch-to-SQL temporary-table flow (TransformIT).

## Fixes

This prevents scheduled Batch Transform jobs from reusing a stale `PemjaWriter` or accumulating data from previous runs.